### PR TITLE
Fix bug on receipts/proforma when reselecting an item will accumulate total price

### DIFF
--- a/public/js/customer/receipt/select_item_proforma.js
+++ b/public/js/customer/receipt/select_item_proforma.js
@@ -216,12 +216,9 @@ function onproformaItemSelectSuggestion(e) {
     console.log($(`#p_sub_total`).val())
     console.log()
     
-    // Add all item total to subtotal
+    // Recalculate total
     calculateproformaSubTotal();
     calculateproformaGrandTotal();
-    // $(`#p_sub_total`).val(parseFloat(parseFloat($(`#p_sub_total`).val()) + parseFloat($(`#p_item_total_${id}`).val())).toFixed(2))
-    // $(`#p_grand_total`).val(parseFloat(parseFloat($(`#p_grand_total`).val()) + parseFloat($(`#p_item_total_${id}`).val())).toFixed(2))
-
 }
 
 function onproformaItemRemove(e) {

--- a/public/js/customer/receipt/select_item_proforma.js
+++ b/public/js/customer/receipt/select_item_proforma.js
@@ -217,8 +217,10 @@ function onproformaItemSelectSuggestion(e) {
     console.log()
     
     // Add all item total to subtotal
-    $(`#p_sub_total`).val(parseFloat(parseFloat($(`#p_sub_total`).val()) + parseFloat($(`#p_item_total_${id}`).val())).toFixed(2))
-    $(`#p_grand_total`).val(parseFloat(parseFloat($(`#p_grand_total`).val()) + parseFloat($(`#p_item_total_${id}`).val())).toFixed(2))
+    calculateproformaSubTotal();
+    calculateproformaGrandTotal();
+    // $(`#p_sub_total`).val(parseFloat(parseFloat($(`#p_sub_total`).val()) + parseFloat($(`#p_item_total_${id}`).val())).toFixed(2))
+    // $(`#p_grand_total`).val(parseFloat(parseFloat($(`#p_grand_total`).val()) + parseFloat($(`#p_item_total_${id}`).val())).toFixed(2))
 
 }
 

--- a/public/js/customer/receipt/select_item_receipt.js
+++ b/public/js/customer/receipt/select_item_receipt.js
@@ -212,8 +212,10 @@ function onReceiptItemSelectSuggestion(e) {
     item_total = e.detail.data.sale_price * e.detail.data.quantity;
     
     // Add all item total to subtotal
-    $(`#r_sub_total`).val(parseFloat(parseFloat($(`#r_sub_total`).val()) + parseFloat($(`#r_item_total_${id}`).val())).toFixed(2))
-    $(`#r_grand_total`).val(parseFloat(parseFloat($(`#r_grand_total`).val()) + parseFloat($(`#r_item_total_${id}`).val())).toFixed(2))
+    calculateReceiptSubTotal();
+    calculateReceiptGrandTotal();
+    // $(`#r_sub_total`).val(parseFloat(parseFloat($(`#r_sub_total`).val()) + parseFloat($(`#r_item_total_${id}`).val())).toFixed(2))
+    // $(`#r_grand_total`).val(parseFloat(parseFloat($(`#r_grand_total`).val()) + parseFloat($(`#r_item_total_${id}`).val())).toFixed(2))
 
 }
 

--- a/public/js/customer/receipt/select_item_receipt.js
+++ b/public/js/customer/receipt/select_item_receipt.js
@@ -211,12 +211,9 @@ function onReceiptItemSelectSuggestion(e) {
 
     item_total = e.detail.data.sale_price * e.detail.data.quantity;
     
-    // Add all item total to subtotal
+    // Recalculate total
     calculateReceiptSubTotal();
     calculateReceiptGrandTotal();
-    // $(`#r_sub_total`).val(parseFloat(parseFloat($(`#r_sub_total`).val()) + parseFloat($(`#r_item_total_${id}`).val())).toFixed(2))
-    // $(`#r_grand_total`).val(parseFloat(parseFloat($(`#r_grand_total`).val()) + parseFloat($(`#r_item_total_${id}`).val())).toFixed(2))
-
 }
 
 function onReceiptItemRemove(e) {


### PR DESCRIPTION
The `on***ItemSelectSuggestion` event will now call `calculate***SubTotal()` and `calculate***GrandTotal()` instead of adding the item price to the total price which resulted to an invalid behavior. It was initially assumed that it is impossible to reselect an item unless it is removed from the field first.
![image](https://user-images.githubusercontent.com/32955000/162550782-1d5ee13f-1336-43f5-9501-3d3a285eeeb9.png)

PS. @ScriptHubs A similar bug may exist in your implementation at Vendor Forms since you replicated those from your past implementation at Receipts. You may replicate the two-liner changes to the affected forms there. 😅🚀