### PR TITLE
Install `laravel-actions` package and refactor creation of `Journal Entries` and `Journal Postings`

### DIFF
--- a/app/Actions/CreateJournalEntry.php
+++ b/app/Actions/CreateJournalEntry.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Actions;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+use App\Models\JournalEntries;
+
+class CreateJournalEntry
+{
+    use AsAction;
+
+    public function handle($date, $notes)
+    {
+        $journal_entry = JournalEntries::create([
+            'date' => $date,
+            'notes' => $notes,
+        ]);
+
+        return $journal_entry;
+    }
+}

--- a/app/Actions/CreateJournalPostings.php
+++ b/app/Actions/CreateJournalPostings.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Actions;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+use App\Models\ChartOfAccounts;
+use App\Models\JournalPostings;
+
+class CreateJournalPostings
+{
+    use AsAction;
+
+    public function handle($journal_entry, $raw_debit_accts, $debit_amount, $raw_credit_accts, $credit_amount)
+    {
+        for($i = 0; $i < count($raw_debit_accts); $i++)
+        {
+            $debit_accounts[$i] = $this->decodeRawAccount($raw_debit_accts[$i]);
+            $coa = ChartOfAccounts::find($debit_accounts[$i]->value);
+
+            $updated_balance = $this->computeCOAUpdatedBalance('debit', $debit_accounts[$i], $coa, $debit_amount[$i]);
+            $this->updateCOABalance($coa, $updated_balance);
+            $this->createJournalPosting('debit', $journal_entry->id, $debit_accounts[$i]->value, $credit_amount[$i], $updated_balance);
+        }
+
+        // Credits
+        for($i = 0; $i < count($raw_credit_accts); $i++)
+        {
+            $credit_accounts[$i] = $this->decodeRawAccount($raw_credit_accts[$i]);
+            $coa = ChartOfAccounts::find($credit_accounts[$i]->value);
+
+            $updated_balance = $this->computeCOAUpdatedBalance('credit', $credit_accounts[$i], $coa, $credit_amount[$i]);
+            $this->updateCOABalance($coa, $updated_balance);
+            $this->createJournalPosting('credit', $journal_entry->id, $credit_accounts[$i]->value, $credit_amount[$i], $updated_balance);
+        }
+    }
+
+    public function decodeRawAccount($acct)
+    {
+        $item = json_decode($acct);
+        return $item[0];
+    }
+
+    public function computeCOAUpdatedBalance($type, $acct, $coa, $amount)
+    {
+        if($type == 'debit')
+        {
+            if($acct->normal_balance == 'Debit')
+                $updated_balance = $coa->current_balance + floatval($amount);
+            else
+                $updated_balance = $coa->current_balance - floatval($amount);
+        }
+        else if($type == 'credit')
+        {
+            if($acct->normal_balance == 'Debit')
+                $updated_balance = $coa->current_balance - floatval($amount);
+            else
+                $updated_balance = $coa->current_balance + floatval($amount);
+        }
+        
+        return $updated_balance;
+    }
+
+    public function updateCOABalance($coa, $updated_balance)
+    {
+        $coa->update([
+            'current_balance' => $updated_balance,
+        ]);
+    }
+
+    public function createJournalPosting($type, $id, $coa_id, $amount, $updated_balance)
+    {
+        JournalPostings::create([
+            'type' => $type,
+            'journal_entry_id' => $id,
+            'chart_of_account_id' => $coa_id,
+            'amount' => $amount,
+            'updated_balance' => $updated_balance,
+            'accounting_period_id' => 1, // TODO: temporarily 1 for now
+        ]);
+    }
+}

--- a/app/Actions/CreateJournalVoucher.php
+++ b/app/Actions/CreateJournalVoucher.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Actions;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+use App\Models\JournalVouchers;
+
+class CreateJournalVoucher
+{
+    use AsAction;
+
+    public function handle($id, $reference_number)
+    {
+        $journal_voucher = JournalVouchers::create([
+            'journal_entry_id' => $id,
+            'reference_number' => $reference_number,
+        ]);
+
+        return $journal_voucher;
+    }
+}

--- a/app/Http/Controllers/JournalVouchersController.php
+++ b/app/Http/Controllers/JournalVouchersController.php
@@ -33,7 +33,7 @@ class JournalVouchersController extends Controller
 
         return view('journals.index', [
             'journalVouchers' => $journalVouchers,
-            'totalAmount' => $totalAmount,
+            'totalAmount' => isset($totalAmount) ? $totalAmount : [],
         ]);
     }
 

--- a/app/Http/Controllers/JournalVouchersController.php
+++ b/app/Http/Controllers/JournalVouchersController.php
@@ -6,6 +6,9 @@ use App\Models\JournalVouchers;
 use App\Models\JournalEntries;
 use App\Models\JournalPostings;
 use App\Models\ChartOfAccounts;
+use App\Actions\CreateJournalEntry;
+use App\Actions\CreateJournalPostings;
+use App\Actions\CreateJournalVoucher;
 use Illuminate\Http\Request;
 
 class JournalVouchersController extends Controller
@@ -52,78 +55,10 @@ class JournalVouchersController extends Controller
      */
     public function store(Request $request)
     {
-        // Create a Journal Entry
-        $journal_entry = JournalEntries::create([
-            'date' => $request->date,
-            'notes' => $request->notes,
-        ]);
+        $journal_entry = CreateJournalEntry::run($request->date, $request->notes);
+        $journal_voucher = CreateJournalVoucher::run($journal_entry->id, $request->reference_number);
 
-        // Create a Journal Voucher Entry
-        $journal_voucher = JournalVouchers::create([
-            'journal_entry_id' => $journal_entry->id,
-            'reference_number' => $request->reference_number,
-        ]);
-
-        // Add Journal Postings and Update the COA Balance accordingly.
-        // Decode json of item tagify fields.
-        // Resulting json_decode will turn into an array of
-        // object, thus it has to be merged.
-
-        // Debits
-        for($i = 0; $i < count($request->debit_accounts); $i++)
-        {
-            $item = json_decode($request->debit_accounts[$i]);
-            $debit_accounts[$i] = $item[0];
-
-            $coa = ChartOfAccounts::find($debit_accounts[$i]->value);
-
-            // Update Balance
-            if($debit_accounts[$i]->normal_balance == 'Debit')
-                $updated_balance = $coa->current_balance + $request->debit_amount[$i];
-            else
-                $updated_balance = $coa->current_balance - $request->debit_amount[$i];
-
-            $coa->update([
-                'current_balance' => $updated_balance,
-            ]);
-
-            JournalPostings::create([
-                'journal_entry_id' => $journal_entry->id,
-                'chart_of_account_id' => $debit_accounts[$i]->value,
-                'accounting_period_id' => 1, // TODO: temporarily 1 for now
-                'type' => 'debit',
-                'amount' => $request->debit_amount[$i],
-                'updated_balance' => $updated_balance,
-            ]);
-        }
-
-        // Credits
-        for($i = 0; $i < count($request->credit_accounts); $i++)
-        {
-            $item = json_decode($request->credit_accounts[$i]);
-            $credit_accounts[$i] = $item[0];
-
-            $coa = ChartOfAccounts::find($credit_accounts[$i]->value);
-
-            // Update Balance
-            if($credit_accounts[$i]->normal_balance == 'Credit')
-                $updated_balance = $coa->current_balance + $request->credit_amount[$i];
-            else
-                $updated_balance = $coa->current_balance - $request->credit_amount[$i];
-
-            $coa->update([
-                'current_balance' => $updated_balance,
-            ]);
-
-            JournalPostings::create([
-                'journal_entry_id' => $journal_entry->id,
-                'chart_of_account_id' => $credit_accounts[$i]->value,
-                'accounting_period_id' => 1, // TODO: temporarily 1 for now
-                'type' => 'credit',
-                'amount' => $request->credit_amount[$i],
-                'updated_balance' => $updated_balance,
-            ]);
-        }
+        CreateJournalPostings::run($journal_entry, $request->debit_accounts, $request->debit_amount, $request->credit_accounts, $request->credit_amount);
 
         return redirect()->route('journals.index')->with('success', 'Successfully created a journal voucher.');
     }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "laravel/framework": "^8.75",
         "laravel/sanctum": "^2.11",
         "laravel/tinker": "^2.5",
-        "laravel/ui": "^3.4"
+        "laravel/ui": "^3.4",
+        "lorisleiva/laravel-actions": "*"
     },
     "require-dev": {
         "facade/ignition": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf14086919a839fe740e00554e4baff6",
+    "content-hash": "8ddc643f48222c3546ca4587be5c4e82",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1717,6 +1717,153 @@
                 }
             ],
             "time": "2021-11-21T11:48:40+00:00"
+        },
+        {
+            "name": "lorisleiva/laravel-actions",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lorisleiva/laravel-actions.git",
+                "reference": "4e60c9fbdfcea7d9977d882f3104c8996b43c169"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lorisleiva/laravel-actions/zipball/4e60c9fbdfcea7d9977d882f3104c8996b43c169",
+                "reference": "4e60c9fbdfcea7d9977d882f3104c8996b43c169",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^8.15|^9.0",
+                "lorisleiva/lody": "^0.3.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^7.0",
+                "pestphp/pest": "^1.2",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Lorisleiva\\Actions\\ActionServiceProvider"
+                    ],
+                    "aliases": {
+                        "Action": "Lorisleiva\\Actions\\Facades\\Actions"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lorisleiva\\Actions\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loris Leiva",
+                    "email": "loris.leiva@gmail.com",
+                    "homepage": "https://lorisleiva.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel components that take care of one specific task",
+            "homepage": "https://github.com/lorisleiva/laravel-actions",
+            "keywords": [
+                "action",
+                "command",
+                "component",
+                "controller",
+                "job",
+                "laravel",
+                "object"
+            ],
+            "support": {
+                "issues": "https://github.com/lorisleiva/laravel-actions/issues",
+                "source": "https://github.com/lorisleiva/laravel-actions/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/lorisleiva",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-27T15:30:59+00:00"
+        },
+        {
+            "name": "lorisleiva/lody",
+            "version": "v0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lorisleiva/lody.git",
+                "reference": "a69b2e5e4e63a07171ace00cfc262bd1c5a311ee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lorisleiva/lody/zipball/a69b2e5e4e63a07171ace00cfc262bd1c5a311ee",
+                "reference": "a69b2e5e4e63a07171ace00cfc262bd1c5a311ee",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^8.0|^9.0",
+                "php": "^8.0|^8.1"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^7.0",
+                "pestphp/pest": "^1.20.0",
+                "phpunit/phpunit": "^9.5.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Lorisleiva\\Lody\\LodyServiceProvider"
+                    ],
+                    "aliases": {
+                        "Lody": "Lorisleiva\\Lody\\Lody"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lorisleiva\\Lody\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loris Leiva",
+                    "email": "loris.leiva@gmail.com",
+                    "homepage": "https://lorisleiva.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Load files and classes as lazy collections in Laravel.",
+            "homepage": "https://github.com/lorisleiva/lody",
+            "keywords": [
+                "classes",
+                "collection",
+                "files",
+                "laravel",
+                "load"
+            ],
+            "support": {
+                "issues": "https://github.com/lorisleiva/lody/issues",
+                "source": "https://github.com/lorisleiva/lody/tree/v0.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/lorisleiva",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-01-25T15:50:27+00:00"
         },
         {
             "name": "monolog/monolog",


### PR DESCRIPTION
Since the creation of journal entries and postings will apply across different modules, there is a need to install a package that will ensure the "DO NOT REPEAT" (DRY) principle is applied.

This pull request will update the composer file and refactor the implementation of Journal Vouchers in the creation of Journal Entries and Journal Postings. Such a change allows the code to be reusable across different modules (Vendors, Customers, etc.)

⚠ Note: **This change will now require PHP >= `v8.0`, so for those running below this version (e.g. `v7.4`) must upgrade to meet the requirement. **
1. Download PHP 8.0: https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/8.0.17/xampp-windows-x64-8.0.17-1-VS16.zip/download
2. Terminate existing processes related to XAMPP, Apache, and PHP.
3. Extract downloaded archive.
4. In existing installation of XAMPP `C:\xampp`, append anything (e.g. `apache74`/`php74`) to `apache` and `php` folders.
5. In extracted archive, copy `apache` and `php` folders.
6. After copying those folders, go to the copied `php` folder and open `php.ini`.
7. Add `C:\` to `extension_dir` and `browscap` in `php.ini`. I believe its line `768` and `1333` respectively.
8. On the HMEZGEB Repository, run `composer install`. This will automatically install `laravel-actions` package.

More on the package at https://laravelactions.com/

Don't hesitate to contact me when you need help on the upgrade.