### PR TITLE
Integrate `Proforma` Field to DB on `Customer > Receipts > Receipts`

### DIFF
--- a/app/Http/Controllers/ReceiptController.php
+++ b/app/Http/Controllers/ReceiptController.php
@@ -471,4 +471,16 @@ class ReceiptController extends Controller
 
         return $proformas;
     }
+
+    public function ajaxGetProforma(ReceiptReferences $proforma)
+    {
+        // Load relationships.
+        $proforma->proforma;
+        $proforma->receiptItems;
+        for($i = 0; $i < count($proforma->receiptItems); $i++)
+            $proforma->receiptItems[$i]->inventory;
+
+        // Return response
+        return $proforma;
+    }
 }

--- a/app/Http/Controllers/ReceiptController.php
+++ b/app/Http/Controllers/ReceiptController.php
@@ -120,6 +120,19 @@ class ReceiptController extends Controller
             $items[$i] = $item[0];
         }
 
+        // Decode Proforma field
+        $p = json_decode($request->proforma);
+        $proforma = isset($p) ? $p[0] : null;
+
+        // If this transaction is linked to Proforma
+        if(isset($proforma))
+        {
+            ReceiptReferences::where('id', $proforma->value)
+                ->update([
+                    'status' => 'paid'
+                ]);
+        }
+
         // Determine receipt status.
         if($request->grand_total == $request->total_amount_received)
             $status = 'paid';
@@ -163,7 +176,7 @@ class ReceiptController extends Controller
             'withholding' => '0.00', // Temporary Withholding
             'tax' => '0.00', // Temporary Tax value
             'receipt_number' => $request->proforma_number, // Temporary reference number
-            'proforma_id' => null, // Temporary proforma id
+            'proforma_id' => isset($proforma) ? $proforma->value : null, // Test
             'payment_method' => $payment_method,
             'total_amount_received' => $request->total_amount_received
         ]);

--- a/app/Http/Controllers/ReceiptController.php
+++ b/app/Http/Controllers/ReceiptController.php
@@ -480,6 +480,7 @@ class ReceiptController extends Controller
             ->leftJoin('proformas', 'proformas.receipt_reference_id', '=', 'receipt_references.id')
             ->where('customer_id', $customer->id)
             ->where('type', 'proforma')
+            ->where('status', 'unpaid')
             ->get();
 
         return $proformas;

--- a/app/Http/Controllers/ReceiptController.php
+++ b/app/Http/Controllers/ReceiptController.php
@@ -452,4 +452,23 @@ class ReceiptController extends Controller
   
         return redirect('receipt/')->with('danger', "Successfully deleted customer");
     }
+
+    /*********** AJAX *************/
+
+    public function ajaxSearchCustomerProforma(Customers $customer, $value)
+    {
+        $proformas = ReceiptReferences::select(
+                'receipt_references.id as value',
+                'receipt_references.reference_number',
+                'receipt_references.date',
+                'proformas.amount',
+                'proformas.due_date',
+            )
+            ->leftJoin('proformas', 'proformas.receipt_reference_id', '=', 'receipt_references.id')
+            ->where('customer_id', $customer->id)
+            ->where('type', 'proforma')
+            ->get();
+
+        return $proformas;
+    }
 }

--- a/app/Models/Inventory.php
+++ b/app/Models/Inventory.php
@@ -27,5 +27,9 @@ class Inventory extends Model
         'totalInventory',
     ];
 
+    public function receiptItems()
+    {
+        return $this->hasMany(ReceiptItems::class);
+    }
 
 }

--- a/app/Models/ReceiptItem.php
+++ b/app/Models/ReceiptItem.php
@@ -20,4 +20,9 @@ class ReceiptItem extends Model
     {
         return $this->belongsTo(ReceiptReferences::class);
     }
+
+    public function inventory()
+    {
+        return $this->belongsTo(Inventory::class, 'inventory_id', 'id');
+    }
 }

--- a/app/Models/ReceiptReferences.php
+++ b/app/Models/ReceiptReferences.php
@@ -52,6 +52,6 @@ class ReceiptReferences extends Model
     }
     public function receiptItems()
     {
-        return $this->hasMany(ReceiptItem::class);
+        return $this->hasMany(ReceiptItem::class, 'receipt_reference_id', 'id');
     }
 }

--- a/public/js/customer/receipt/select_customer_proforma.js
+++ b/public/js/customer/receipt/select_customer_proforma.js
@@ -62,20 +62,21 @@ function onProformaCustomerRemove(e){
 }
 
 function onProformaCustomerInput(e) {
+    tagify = e.detail.tagify;
     var value = e.detail.value
-    proforma_select_customer_tagify.whitelist = null // reset the whitelist
+    tagify.whitelist = null // reset the whitelist
 
     // https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort
     controller && controller.abort()
     controller = new AbortController()
 
     // show loading animation and hide the suggestions dropdown
-    proforma_select_customer_tagify.loading(true).dropdown.hide()
+    tagify.loading(true).dropdown.hide()
 
     fetch('/select/search/customer/' + value, {signal:controller.signal})
         .then(RES => RES.json())
         .then(function(newWhitelist){
-            proforma_select_customer_tagify.whitelist = newWhitelist // update whitelist Array in-place
-            proforma_select_customer_tagify.loading(false).dropdown.show(value) // render the suggestions dropdown
+            tagify.whitelist = newWhitelist // update whitelist Array in-place
+            tagify.loading(false).dropdown.show(value) // render the suggestions dropdown
         })
 }

--- a/public/js/customer/receipt/select_customer_receipt.js
+++ b/public/js/customer/receipt/select_customer_receipt.js
@@ -1,4 +1,5 @@
 var receipt_select_customer_elm = document.querySelector('#r_customer');
+var receipt_customer_id = undefined;
 
 // initialize Tagify on the above input node reference
 var receipt_select_customer_tagify = new Tagify(receipt_select_customer_elm, {
@@ -59,6 +60,12 @@ function onReceiptCustomerRemove(e){
     $("#r_tin_number").val("")
     $("#r_contact_person").val("")
     $("#r_mobile_number").val("")
+    $("#r-proforma-remove").click();
+
+    if(proforma_select_customer_tagify !== undefined)
+    {
+        proforma_select_customer_tagify.whitelist = null; // reset the whitelist
+    }
 }
 
 function onReceiptCustomerInput(e) {

--- a/public/js/customer/receipt/select_customer_receipt.js
+++ b/public/js/customer/receipt/select_customer_receipt.js
@@ -1,5 +1,5 @@
 var receipt_select_customer_elm = document.querySelector('#r_customer');
-var receipt_customer_id = undefined;
+var receipt_customer_id = undefined; // used to enable proforma field
 
 // initialize Tagify on the above input node reference
 var receipt_select_customer_tagify = new Tagify(receipt_select_customer_elm, {
@@ -48,6 +48,7 @@ function onDropdownShow(e){
 function onReceiptCustomerSelectSuggestion(e){
     // checks for data of selected customer
     console.log(e.detail.data);
+    receipt_customer_id = e.detail.data.value;
 
     $("#r_customer_id").val(e.detail.data.value)
     $("#r_tin_number").val(e.detail.data.tin_number)

--- a/public/js/customer/receipt/select_item_receipt.js
+++ b/public/js/customer/receipt/select_item_receipt.js
@@ -85,19 +85,21 @@ function createReceiptItemEntry(item = undefined)
 
     // Set values if item exists.
     if(item != undefined) {
-        $(`#r_item_${receipt_count}`).val(item.id);
-        $(`#r_item_quantity_${receipt_count}`).val(item.quantity).removeAttr('disabled');
-        $(`#r_item_price_${receipt_count}`).val(parseFloat(item.price).toFixed(2))
-        $(`#r_item_total_${receipt_count}`).val(parseFloat(item.price * item.quantity).toFixed(2))
-
         whitelist = [
             {
-                "value": item.id,
-                "name": item.name,
-                "sale_price": item.price,
+                "value": item.inventory.id,
+                "name": item.inventory.item_name,
+                "sale_price": item.inventory.sale_price,
                 "quantity": item.quantity,
             },
         ];
+        
+        
+        $(`#r_item_${receipt_count}`).val(item.inventory.item_name);
+        $(`#r_item_quantity_${receipt_count}`).val(item.quantity).removeAttr('disabled');
+        $(`#r_item_price_${receipt_count}`).val(parseFloat(item.inventory.sale_price).toFixed(2))
+        $(`#r_item_total_${receipt_count}`).val(parseFloat(item.inventory.sale_price * item.quantity).toFixed(2))
+        
     }
 
     // Create new tagify instance of item selector of newly created row.

--- a/public/js/customer/receipt/select_item_receipt.js
+++ b/public/js/customer/receipt/select_item_receipt.js
@@ -111,7 +111,7 @@ function createReceiptItemEntry(item = undefined)
             closeOnSelect: true,
             enabled: 0,
             classname: 'item-list',
-            searchKeys: ['name', 'email'] // very important to set by which keys to search for suggesttions when typing
+            searchKeys: ['name'] // very important to set by which keys to search for suggesttions when typing
         },
         templates: {
             tag: ItemTagTemplate,

--- a/public/js/customer/receipt/select_item_receipt.js
+++ b/public/js/customer/receipt/select_item_receipt.js
@@ -35,7 +35,7 @@ $(document).on('change', '.r_item_quantity', function(event) {
 });
 
 // Creates a Receipt Item Entry on the Table.
-function createReceiptItemEntry() 
+function createReceiptItemEntry(item = undefined) 
 {
     // Increment receipt_count to avoid element conflicts.
     receipt_count++;
@@ -81,6 +81,25 @@ function createReceiptItemEntry()
     // Append template to the table.
     $("#r_items").append(inner)
 
+    var whitelist = [];
+
+    // Set values if item exists.
+    if(item != undefined) {
+        $(`#r_item_${receipt_count}`).val(item.id);
+        $(`#r_item_quantity_${receipt_count}`).val(item.quantity).removeAttr('disabled');
+        $(`#r_item_price_${receipt_count}`).val(parseFloat(item.price).toFixed(2))
+        $(`#r_item_total_${receipt_count}`).val(parseFloat(item.price * item.quantity).toFixed(2))
+
+        whitelist = [
+            {
+                "value": item.id,
+                "name": item.name,
+                "sale_price": item.price,
+                "quantity": item.quantity,
+            },
+        ];
+    }
+
     // Create new tagify instance of item selector of newly created row.
     let elm = document.querySelector(`#r_item_${receipt_count}`);
     let elm_tagify = new Tagify(elm, {
@@ -98,8 +117,8 @@ function createReceiptItemEntry()
             tag: ItemTagTemplate,
             dropdownItem: ItemSuggestionItemTemplate
         },
-        whitelist: [],
-    })
+        whitelist: whitelist,
+    });
 
     // Set events of tagify instance.
     elm_tagify.on('dropdown:show dropdown:updated', onReceiptItemDropdownShow)

--- a/public/js/customer/receipt/select_proforma_receipt.js
+++ b/public/js/customer/receipt/select_proforma_receipt.js
@@ -10,7 +10,7 @@ var receipt_select_proforma_tagify = new Tagify(receipt_select_proforma_elm, {
         closeOnSelect: true,
         enabled: 0,
         classname: 'receipts-proforma-list',
-        searchKeys: ['value', ]  // very important to set by which keys to search for suggesttions when typing
+        searchKeys: ['value', 'reference_number']  // very important to set by which keys to search for suggesttions when typing
     },
     templates: {
         tag: proformaTagTemplate,

--- a/public/js/customer/receipt/select_proforma_receipt.js
+++ b/public/js/customer/receipt/select_proforma_receipt.js
@@ -1,0 +1,79 @@
+var proforma_select_customer_elm = document.querySelector('#r_proforma');
+
+// initialize Tagify on the above input node reference
+var proforma_select_customer_tagify = new Tagify(proforma_select_customer_elm, {
+    tagTextProp: 'reference_number', // very important since a custom template is used with this property as text
+    enforceWhitelist: true,
+    mode : "select",
+    skipInvalid: false, // do not remporarily add invalid tags
+    dropdown: {
+        closeOnSelect: true,
+        enabled: 0,
+        classname: 'receipts-proforma-list',
+        searchKeys: ['value', ]  // very important to set by which keys to search for suggesttions when typing
+    },
+    templates: {
+        tag: proformaTagTemplate,
+        dropdownItem: proformaSuggestionItemTemplate
+    },
+    whitelist: [],
+    // whitelist: [
+    //     {
+    //         "value": 1,
+    //         "name": "Justinian Hattersley",
+    //         "avatar": "https://i.pravatar.cc/80?img=1",
+    //         "email": "jhattersley0@ucsd.edu"
+    //     },
+    // ]
+})
+
+// proforma_select_customer_tagify.on('dropdown:show dropdown:updated', onDropdownShow)
+proforma_select_customer_tagify.on('dropdown:select', onReceiptProformaSelectSuggestion)
+proforma_select_customer_tagify.on('input', onReceiptProformaInput)
+proforma_select_customer_tagify.on('remove', onReceiptProformaRemove)
+
+var addAllSuggestionsElm;
+
+function onDropdownShow(e){
+    var dropdownContentElm = e.detail.proforma_select_customer_tagify.DOM.dropdown.content;
+}
+
+function onReceiptProformaSelectSuggestion(e){
+    // checks for data of selected customer
+    console.log(e.detail.data);
+
+    // $("#r_customer_id").html(e.detail.data.value)
+    // $("#r_tin_number").html(e.detail.data.tin_number)
+    // $("#r_contact_person").html(e.detail.data.contact_person)
+    // $("#r_mobile_number").html(e.detail.data.mobile_number)
+}
+
+function onReceiptProformaRemove(e){
+    // $("#r_customer_id").html("")
+    // $("#r_tin_number").html("")
+    // $("#r_contact_person").html("")
+    // $("#r_mobile_number").html("")
+}
+
+function onReceiptProformaInput(e) {
+    var value = e.detail.value
+    proforma_select_customer_tagify.whitelist = null // reset the whitelist
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort
+    controller && controller.abort()
+    controller = new AbortController()
+
+    if(receipt_customer_id != undefined)
+    {
+        // show loading animation and hide the suggestions dropdown
+        proforma_select_customer_tagify.loading(true).dropdown.hide()
+    
+        fetch(`/ajax/customer/receipt/proforma/search/${receipt_customer_id}/${value}`, {signal:controller.signal})
+            .then(RES => RES.json())
+            .then(function(newWhitelist){
+                proforma_select_customer_tagify.whitelist = newWhitelist // update whitelist Array in-place
+                proforma_select_customer_tagify.loading(false).dropdown.show(value) // render the suggestions dropdown
+            })
+    }
+
+}

--- a/public/js/customer/receipt/select_proforma_receipt.js
+++ b/public/js/customer/receipt/select_proforma_receipt.js
@@ -41,6 +41,31 @@ function onDropdownShow(e){
 function onReceiptProformaSelectSuggestion(e){
     // checks for data of selected customer
     console.log(e.detail.data);
+    let proforma_id = e.detail.data.value;
+
+    request = $.get(`/ajax/customer/receipt/proforma/get/${proforma_id}`);
+    
+    request.done(function(response, textStatus, jqXHR){
+        console.log(response);
+        // Clear item list
+        $("#r_items").html("");
+
+        // Create receipt item entries bearing values from proforma.
+        response.receipt_items.forEach(function(item){
+            // console.log(item);
+
+            createReceiptItemEntry(item);
+        });
+
+        // Compute subtotal & grandtotal
+        calculateReceiptSubTotal();
+        calculateReceiptGrandTotal();
+    });
+    
+    request.fail(function(jqXHR, textStatus, errorThrown){
+        console.log(jqXHR);
+        console.log(errorThrown);
+    });
 
     // $("#r_customer_id").html(e.detail.data.value)
     // $("#r_tin_number").html(e.detail.data.tin_number)

--- a/public/js/customer/receipt/select_proforma_receipt.js
+++ b/public/js/customer/receipt/select_proforma_receipt.js
@@ -1,7 +1,7 @@
-var proforma_select_customer_elm = document.querySelector('#r_proforma');
+var receipt_select_proforma_elm = document.querySelector('#r_proforma');
 
 // initialize Tagify on the above input node reference
-var proforma_select_customer_tagify = new Tagify(proforma_select_customer_elm, {
+var receipt_select_proforma_tagify = new Tagify(receipt_select_proforma_elm, {
     tagTextProp: 'reference_number', // very important since a custom template is used with this property as text
     enforceWhitelist: true,
     mode : "select",
@@ -27,15 +27,15 @@ var proforma_select_customer_tagify = new Tagify(proforma_select_customer_elm, {
     // ]
 })
 
-// proforma_select_customer_tagify.on('dropdown:show dropdown:updated', onDropdownShow)
-proforma_select_customer_tagify.on('dropdown:select', onReceiptProformaSelectSuggestion)
-proforma_select_customer_tagify.on('input', onReceiptProformaInput)
-proforma_select_customer_tagify.on('remove', onReceiptProformaRemove)
+// receipt_select_proforma_tagify.on('dropdown:show dropdown:updated', onDropdownShow)
+receipt_select_proforma_tagify.on('dropdown:select', onReceiptProformaSelectSuggestion)
+receipt_select_proforma_tagify.on('input', onReceiptProformaInput)
+receipt_select_proforma_tagify.on('remove', onReceiptProformaRemove)
 
 var addAllSuggestionsElm;
 
 function onDropdownShow(e){
-    var dropdownContentElm = e.detail.proforma_select_customer_tagify.DOM.dropdown.content;
+    var dropdownContentElm = e.detail.receipt_select_proforma_tagify.DOM.dropdown.content;
 }
 
 function onReceiptProformaSelectSuggestion(e){
@@ -56,8 +56,9 @@ function onReceiptProformaRemove(e){
 }
 
 function onReceiptProformaInput(e) {
+    tagify = e.detail.tagify;
     var value = e.detail.value
-    proforma_select_customer_tagify.whitelist = null // reset the whitelist
+    tagify.whitelist = null // reset the whitelist
 
     // https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort
     controller && controller.abort()
@@ -66,13 +67,13 @@ function onReceiptProformaInput(e) {
     if(receipt_customer_id != undefined)
     {
         // show loading animation and hide the suggestions dropdown
-        proforma_select_customer_tagify.loading(true).dropdown.hide()
+        tagify.loading(true).dropdown.hide()
     
         fetch(`/ajax/customer/receipt/proforma/search/${receipt_customer_id}/${value}`, {signal:controller.signal})
             .then(RES => RES.json())
             .then(function(newWhitelist){
-                proforma_select_customer_tagify.whitelist = newWhitelist // update whitelist Array in-place
-                proforma_select_customer_tagify.loading(false).dropdown.show(value) // render the suggestions dropdown
+                tagify.whitelist = newWhitelist // update whitelist Array in-place
+                tagify.loading(false).dropdown.show(value) // render the suggestions dropdown
             })
     }
 

--- a/public/js/customer/receipt/template_select_proforma.js
+++ b/public/js/customer/receipt/template_select_proforma.js
@@ -1,0 +1,28 @@
+function proformaTagTemplate(tagData){
+    return `
+        <tag title="${tagData.value}"
+                contenteditable='false'
+                spellcheck='false'
+                tabIndex="-1"
+                class="tagify__tag ${tagData.class ? tagData.class : ""}"
+                ${this.getAttributes(tagData)}>
+            <x title='' id="r-proforma-remove" class='tagify__tag__removeBtn' role='button' aria-label='remove tag'></x>
+            <div>
+                <span class='tagify__tag-text'>Fs#${tagData.reference_number}</span>
+            </div>
+        </tag>
+    `
+}
+
+function proformaSuggestionItemTemplate(tagData){
+    return `
+        <div ${this.getAttributes(tagData)}
+            class='tagify__dropdown__item ${tagData.class ? tagData.class : ""}'
+            tabindex="0"
+            role="option">
+            <strong>Fs#${tagData.reference_number}</strong><br>
+            <small>Date: ${tagData.date}</small><br>
+            <small>Amount: ${tagData.amount}</small>
+        </div>
+    `
+}

--- a/resources/views/customer/receipt/forms/receipt.blade.php
+++ b/resources/views/customer/receipt/forms/receipt.blade.php
@@ -36,9 +36,9 @@
                 </div>
             </div>
             <div class="form-group row">
-                <label for="r_proforma_number" class="col-4 col-form-label text-lg-right">Proforma # :</label>
+                <label for="r_proforma" class="col-4 col-form-label text-lg-right">Proforma # :</label>
                 <div class="col-8">
-                    <input type="text" class="form-control" id="r_proforma_number" name="proforma_number" placeholder="">
+                    <input type="text" id="r_proforma" name="proforma">
                 </div>
             </div>
             <div class="form-group row">

--- a/resources/views/customer/receipt/index.blade.php
+++ b/resources/views/customer/receipt/index.blade.php
@@ -549,5 +549,6 @@ POTENTIAL SOLUTIONS:
     <script src="/js/customer/receipt/select_item_proforma.js"></script>
     <script src="/js/customer/receipt/select_receipt_creditreceipt.js"></script>
 
-
+    <script src="/js/customer/receipt/template_select_proforma.js"></script>
+    <script src="/js/customer/receipt/select_proforma_receipt.js"></script>
     @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -113,6 +113,8 @@ Route::post('/userlogin', function (Request $request){
         Route::get('/receipt/{id}', [ReceiptController::class, 'edit']);
         Route::put('/receipt/{id}', [ReceiptController::class, 'update']);
 
+        Route::get('/ajax/customer/receipt/proforma/search/{customer}/{value}', [ReceiptController::class, 'ajaxSearchCustomerProforma']);
+
         
     });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -113,9 +113,9 @@ Route::post('/userlogin', function (Request $request){
         Route::get('/receipt/{id}', [ReceiptController::class, 'edit']);
         Route::put('/receipt/{id}', [ReceiptController::class, 'update']);
 
+        /** AJAX Calls */
         Route::get('/ajax/customer/receipt/proforma/search/{customer}/{value}', [ReceiptController::class, 'ajaxSearchCustomerProforma']);
-
-        
+        Route::get('/ajax/customer/receipt/proforma/get/{proforma}', [ReceiptController::class, 'ajaxGetProforma']);
     });
 
     Route::group([


### PR DESCRIPTION
This PR allows Proforma Contents to be loaded to Receipts Form when a Proforma is selected.

- [x] Fetch Customer's Proformas
- [x] Load Proforma Contents to Receipts Form
- [x] Test calculations
- [x] Removing proforma to list when such a proforma is already linked to receipts.
- [x] When proforma contents is modified in receipts, will its reference be removed or just keep it? -- I think keeping it is feasible. It will eventually be modified when another proforma is selected.

Ready for review, @justinmanigo .