### PR TITLE
Implement Normal Referral Code Generation

### DIFF
--- a/app/Http/Controllers/ReferralsController.php
+++ b/app/Http/Controllers/ReferralsController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\Referral;
+use App\Http\Requests\StoreReferralRequest;
+use Illuminate\Support\Facades\Auth;
 
 class ReferralsController extends Controller
 {
@@ -14,5 +16,17 @@ class ReferralsController extends Controller
             'referrals' => $referrals,
         ]);
     }
+
+    public function storeNormalReferral(StoreReferralRequest $request)
+    {
+        $validated = $request->validated();
+
+        Referral::create([
+            'user_id' => Auth::user()->id,
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+        ]);
+
+        return redirect('/referrals')->with('success', 'Successfully created a referral.');
     }
 }

--- a/app/Http/Controllers/ReferralsController.php
+++ b/app/Http/Controllers/ReferralsController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ReferralsController extends Controller
+{
+    public function index()
+    {
+        return view('referrals.index');
+    }
+}

--- a/app/Http/Controllers/ReferralsController.php
+++ b/app/Http/Controllers/ReferralsController.php
@@ -2,12 +2,17 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Models\Referral;
 
 class ReferralsController extends Controller
 {
     public function index()
     {
-        return view('referrals.index');
+        $referrals = Referral::where('user_id', Auth::id())->get();
+
+        return view('referrals.index', [
+            'referrals' => $referrals,
+        ]);
+    }
     }
 }

--- a/app/Http/Requests/StoreReferralRequest.php
+++ b/app/Http/Requests/StoreReferralRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreReferralRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'type' => ['sometimes'],
+            'name' => ['required'],
+            'email' => ['required', 'email'],
+        ];
+    }
+}

--- a/app/Http/Traits/HasReferralCode.php
+++ b/app/Http/Traits/HasReferralCode.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Traits;
+
+use Kaiopiola\Keygen\Key;
+
+/**
+ * Credits to James Mills
+ * https://github.com/jamesmills/eloquent-uuid/blob/master/src/HasUuidTrait.php
+ */
+trait HasReferralCode
+{
+    protected static function bootHasReferralCode()
+    {
+        static::creating(function ($model) {
+
+            if (!$model->code) {
+                $exampleKey = new Key;
+                $exampleKey->setPattern("XXXXX-XXXXX-XXXXX");
+                $model->code = (string)$exampleKey->generate();
+            }
+        });
+    }
+}

--- a/app/Models/Referral.php
+++ b/app/Models/Referral.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Referral extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'code',
+        'type',
+        'name',
+        'email',
+        'commission',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Referral.php
+++ b/app/Models/Referral.php
@@ -4,14 +4,14 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Http\Traits\HasReferralCode;
 
 class Referral extends Model
 {
-    use HasFactory;
+    use HasFactory, HasReferralCode;
 
     protected $fillable = [
         'user_id',
-        'code',
         'type',
         'name',
         'email',

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -12,13 +12,10 @@ class Subscription extends Model
     protected $fillable = [
         'user_id',
         'account_limit',
-        'referral_user_id',
-        'referral_code',
-        'referral_type',
         'trial_from',
         'trial_to',
-        'status',   // temporarily added just in case its needed. 
-                    // was disabled in migrations
+        'active_since_at',
+        'payment_status',
     ];
 
     public function user()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -51,6 +51,11 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
     ];
 
+    public function referrals()
+    {
+        return $this->hasMany(Referral::class);
+    }
+
     public function permissions()
     {
         return $this->hasMany(Permission::class);

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "php": "^7.3|^8.0",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
+        "kaiopiola/keygen": "^1.2",
         "laravel/fortify": "^1.12",
         "laravel/framework": "^8.75",
         "laravel/sanctum": "^2.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e7f230ae050f01ed9caf2211d4516340",
+    "content-hash": "c55271969b06b6682fbcfcc24c2c661c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1057,6 +1057,49 @@
                 }
             ],
             "time": "2022-03-20T21:55:58+00:00"
+        },
+        {
+            "name": "kaiopiola/keygen",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kaiopiola/keygen-package.git",
+                "reference": "b8265af36d1368d1d7287f52d7da5fa8e69897fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kaiopiola/keygen-package/zipball/b8265af36d1368d1d7287f52d7da5fa8e69897fa",
+                "reference": "b8265af36d1368d1d7287f52d7da5fa8e69897fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "package",
+            "autoload": {
+                "psr-4": {
+                    "Kaiopiola\\Keygen\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kaio Piola",
+                    "email": "kaio.piola@hotmail.com"
+                }
+            ],
+            "description": "Pattern-based key generator",
+            "support": {
+                "issues": "https://github.com/kaiopiola/keygen-package/issues",
+                "source": "https://github.com/kaiopiola/keygen-package/tree/1.2.0"
+            },
+            "time": "2022-01-18T00:31:33+00:00"
         },
         {
             "name": "laravel/fortify",

--- a/database/migrations/2022_05_14_071921_create_referrals_table.php
+++ b/database/migrations/2022_05_14_071921_create_referrals_table.php
@@ -16,7 +16,7 @@ class CreateReferralsTable extends Migration
         Schema::create('referrals', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained();
-            $table->string('code');
+            $table->string('code')->unique();
             $table->enum('type', [
                 'normal',
                 'advanced',

--- a/database/migrations/2022_05_14_071921_create_referrals_table.php
+++ b/database/migrations/2022_05_14_071921_create_referrals_table.php
@@ -21,7 +21,6 @@ class CreateReferralsTable extends Migration
                 'normal',
                 'advanced',
             ]);
-            $table->tinyInteger('account_limit');
             $table->string('name');
             $table->string('email');
             $table->float('commission')->nullable();

--- a/database/migrations/2022_05_14_071921_create_referrals_table.php
+++ b/database/migrations/2022_05_14_071921_create_referrals_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSubscriptionsTable extends Migration
+class CreateReferralsTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,17 +13,18 @@ class CreateSubscriptionsTable extends Migration
      */
     public function up()
     {
-        Schema::create('subscriptions', function (Blueprint $table) {
+        Schema::create('referrals', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained();
+            $table->string('code');
+            $table->enum('type', [
+                'normal',
+                'advanced',
+            ]);
             $table->tinyInteger('account_limit');
-            $table->date('trial_from')->nullable();
-            $table->date('trial_to')->nullable();
-            $table->enum('payment_status', [ 
-                'pending',
-                'paid',
-            ])->nullable();
-            $table->timestamp('active_since_at')->nullable();
+            $table->string('name');
+            $table->string('email');
+            $table->float('commission')->nullable();
             $table->timestamps();
         });
     }
@@ -35,6 +36,6 @@ class CreateSubscriptionsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('subscriptions');
+        Schema::dropIfExists('referrals');
     }
 }

--- a/database/migrations/2022_05_14_071921_create_referrals_table.php
+++ b/database/migrations/2022_05_14_071921_create_referrals_table.php
@@ -20,7 +20,7 @@ class CreateReferralsTable extends Migration
             $table->enum('type', [
                 'normal',
                 'advanced',
-            ]);
+            ])->default('normal');
             $table->string('name');
             $table->string('email');
             $table->float('commission')->nullable();

--- a/resources/views/referrals/index.blade.php
+++ b/resources/views/referrals/index.blade.php
@@ -1,0 +1,28 @@
+@extends('template.index')
+
+@push('styles')
+<style>
+    .table-item-content { 
+        /** Equivalent to pt-3 */
+        padding-top:1rem!important;
+    }
+
+    #thead-actions {
+        /** Fixed width, increase if adding addt. buttons **/
+        width:120px;
+    }
+</style>
+@endpush
+
+@push('scripts')
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"></script> 
+@endpush
+
+@section('content')
+
+<div class="row">
+    <p>Referrals</p>
+</div>
+
+<script src="https://cdn.datatables.net/1.11.2/js/jquery.dataTables.min.js"></script>
+@endsection

--- a/resources/views/referrals/index.blade.php
+++ b/resources/views/referrals/index.blade.php
@@ -27,7 +27,7 @@
             <span class="icon text-white-50">
                 <i class="fas fa-file-import"></i>
             </span>
-            <span class="text">New</span>
+            <span class="text">New Normal Referral</span>
         </button>
     </div>  
 </div>

--- a/resources/views/referrals/index.blade.php
+++ b/resources/views/referrals/index.blade.php
@@ -20,8 +20,96 @@
 
 @section('content')
 
-<div class="row">
-    <p>Referrals</p>
+<div class="d-sm-flex align-items-start justify-content-between mb-2">
+    <h1>Referrals</h1>
+    <div class="btn-group" role="group">
+        <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#modal-referral">
+            <span class="icon text-white-50">
+                <i class="fas fa-file-import"></i>
+            </span>
+            <span class="text">New</span>
+        </button>
+    </div>  
+</div>
+
+<div class="card">
+    <div class="card-body">
+        <div class="table-responsive">
+            <table class="table table-bordered">
+                <thead>
+                    <th>Referral Code</th>
+                    <th>Date Created</th>
+                    <th>Name</th>
+                    <th>Email</th>
+                    <th>Action</th>
+                </thead>
+                <tbody>
+                    @if(count($referrals) < 1)
+                    <tr>
+                        <td colspan='5'>You don't have referrals at the moment. Invite someone to use HMEZGEB now.</td>
+                    </tr>
+                    @endif
+
+                    @foreach($referrals as $referral)
+                        <tr>
+                            <td>{{ $referral->code }}</td>
+                            <td>{{ \Carbon\Carbon::parse($referral->created_at)->format('Y-m-d') }}</td>
+                            <td>{{ $referral->name }}</td>
+                            <td>{{ $referral->email }}</td>
+                            <td>
+                                <button type="button" class="btn btn-small btn-icon btn-primary" onclick="javascript:void(0)" disabled>
+                                    <span class="icon text-white-50">
+                                        <i class="fas fa-envelope"></i>
+                                    </span>
+                                    Resend Email
+                                </button>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+{{-- Modals --}}
+{{-- New Referral --}}
+<div class="modal fade" id="modal-referral" tabindex="-1" role="dialog" aria-labelledby="modal-referral-label" aria-hidden="true">
+    <div class="modal-dialog modal-md" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modal-referral-label">New Normal Referral</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div id="modal-referral-spinner" class="spinner-border text-center p-5" role="status" style="display:none">
+                    <span class="sr-only">Loading...</span>
+                </div>
+                <form id="form-referral" method="post" action="{{ url('/referrals') }}">
+                    @csrf
+                    <div class="form-group row">
+                        <label for="r_name" class="col-12 col-lg-6 col-form-label">Name<span class="text-danger ml-1">*</span></label>
+                        <div class="col-12 col-lg-6">
+                            <input type="text" class="form-control" id="r_name" name="name" required>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <label for="r_email" class="col-12 col-lg-6 col-form-label">Email<span class="text-danger ml-1">*</span></label>
+                        <div class="col-12 col-lg-6">
+                            <input type="email" class="form-control" id="r_email" name="email" required>
+                        </div>
+                    </div>
+                    <p>The referral code is auto-generated on submission.</p>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                <button type="submit" class="btn btn-primary" id="r_submit_btn" form="form-referral">Create and Send Invitation</button>
+            </div>
+        </div>
+    </div>
 </div>
 
 <script src="https://cdn.datatables.net/1.11.2/js/jquery.dataTables.min.js"></script>

--- a/resources/views/template/navbar.blade.php
+++ b/resources/views/template/navbar.blade.php
@@ -304,13 +304,17 @@
                                     <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray-400"></i>
                                     Account Settings
                                 </a>
+                                <a class="dropdown-item" href="/referrals/">
+                                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray-400"></i>
+                                    Referrals
+                                </a>
+                                <div class="dropdown-divider"></div>
                                 @if($accounting_system_count > 1)
                                     <a class="dropdown-item" href="{{ url('/switch') }}">
                                         <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray-400"></i>
                                         Switch Accounting Systems
                                     </a>
                                 @endif
-                                <div class="dropdown-divider"></div>
                                 <a class="dropdown-item" href="#" data-toggle="modal" data-target="#logoutModal">
                                     <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray-400"></i>
                                     Logout

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,6 +68,12 @@ Route::group([
     ], function(){
         Route::get('/', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
         Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
+        
+        Route::group([
+            'as' => 'referrals.'
+        ], function(){
+            Route::get('/referrals', [App\Http\Controllers\ReferralsController::class, 'index'])->name('index');
+        });
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -73,6 +73,7 @@ Route::group([
             'as' => 'referrals.'
         ], function(){
             Route::get('/referrals', [App\Http\Controllers\ReferralsController::class, 'index'])->name('index');
+            Route::post('/referrals', [App\Http\Controllers\ReferralsController::class, 'storeNormalReferral'])->name('store.normal');
         });
     });
 });


### PR DESCRIPTION
This PR implements the normal referral code generation feature. It uses the `kaiopiola\keygen` laravel package.

The code consists of random 15-character string separated by a dash `-` for 5 characters each (e.g. `XXXXX-XXXXX-XXXXX`). The code is auto-generated every time a new referral is made using a custom-made `HasReferral` trait intended for `Referral` model.

Prior to code generation, the system asks for the `name` and `email`. Then the details along with the auto-generated referral code is stored to the database.

![image](https://user-images.githubusercontent.com/32955000/168417693-04a12602-4451-4a9f-8a10-923d74ce3dfd.png)
