### PR TITLE
Modified Accounting Period Model to support Gregorian Date equivalents of Ethiopian Calendar

### DIFF
--- a/app/Actions/GenerateAccountingPeriods.php
+++ b/app/Actions/GenerateAccountingPeriods.php
@@ -1,0 +1,404 @@
+<?php
+
+namespace App\Actions;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+use Illuminate\Support\Facades\DB;
+
+class GenerateAccountingPeriods
+{
+    use AsAction;
+
+    private $accounting_periods_template = [
+        [
+            'period_number' => 1,
+            // Gregorian Common
+            'month_from' => 1,
+            'day_from' => 1,
+            'month_to' => 1,
+            'day_to' => 31,
+            // Gregorian Leap
+            'month_from_leap' => 1,
+            'day_from_leap' => 1,
+            'month_to_leap' => 1,
+            'day_to_leap' => 31,
+            // Ethiopian Common
+            'month_from_ethiopian' => 7,
+            'month_to_ethiopian' => 8,
+            'day_from_ethiopian' => 8,
+            'day_to_ethiopian' => 6,
+            // Ethiopian Leap
+            'month_from_ethiopian_leap' => 7,
+            'month_to_ethiopian_leap' => 8,
+            'day_from_ethiopian_leap' => 8,
+            'day_to_ethiopian_leap' => 6,
+        ],
+        [
+            'period_number' => 2,
+            // Gregorian Common
+            'month_from' => 2,
+            'day_from' => 1,
+            'month_to' => 2,
+            'day_to' => 28,
+            // Gregorian Leap
+            'month_from_leap' => 2,
+            'day_from_leap' => 1,
+            'month_to_leap' => 2,
+            'day_to_leap' => 29,
+            // Ethiopian Common
+            'month_from_ethiopian' => 8,
+            'day_from_ethiopian' => 7,
+            'month_to_ethiopian' => 9,
+            'day_to_ethiopian' => 10,
+            // Ethiopian Leap
+            'month_from_ethiopian_leap' => 8,
+            'day_from_ethiopian_leap' => 7,
+            'month_to_ethiopian_leap' => 9,
+            'day_to_ethiopian_leap' => 11,
+        ],
+        [
+            'period_number' => 3,
+            // Gregorian Common
+            'month_from' => 3,
+            'day_from' => 1,
+            'month_to' => 3,
+            'day_to' => 31,
+            // Gregorian Leap
+            'month_from_leap' => 3,
+            'day_from_leap' => 1,
+            'month_to_leap' => 3,
+            'day_to_leap' => 31,
+            // Ethiopian Common
+            'month_from_ethiopian' => 9,
+            'day_from_ethiopian' => 11,
+            'month_to_ethiopian' => 10,
+            'day_to_ethiopian' => 10,
+            // Ethiopian Leap
+            'month_from_ethiopian_leap' => 9,
+            'day_from_ethiopian_leap' => 12,
+            'month_to_ethiopian_leap' => 10,
+            'day_to_ethiopian_leap' => 11,
+        ],
+        [
+            'period_number' => 4,
+            // Gregorian Common
+            'month_from' => 4,
+            'day_from' => 1,
+            'month_to' => 4,
+            'day_to' => 30,
+            // Gregorian Leap
+            'month_from_leap' => 4,
+            'day_from_leap' => 1,
+            'month_to_leap' => 4,
+            'day_to_leap' => 30,
+            // Ethiopian Common
+            'month_from_ethiopian' => 10,
+            'day_from_ethiopian' => 11,
+            'month_to_ethiopian' => 11,
+            'day_to_ethiopian' => 9,
+            // Ethiopian Leap
+            'month_from_ethiopian_leap' => 10,
+            'day_from_ethiopian_leap' => 12,
+            'month_to_ethiopian_leap' => 11,
+            'day_to_ethiopian_leap' => 10,
+        ],
+        [
+            'period_number' => 5,
+            // Gregorian Common
+            'month_from' => 5,
+            'day_from' => 1,
+            'month_to' => 5,
+            'day_to' => 31,
+            // Gregorian Leap
+            'month_from_leap' => 5,
+            'day_from_leap' => 1,
+            'month_to_leap' => 5,
+            'day_to_leap' => 31,
+            // Ethiopian Common
+            'month_from_ethiopian' => 11,
+            'day_from_ethiopian' => 10,
+            'month_to_ethiopian' => 12,
+            'day_to_ethiopian' => 9,
+            // Ethiopian Leap
+            'month_from_ethiopian_leap' => 11,
+            'day_from_ethiopian_leap' => 11,
+            'month_to_ethiopian_leap' => 12,
+            'day_to_ethiopian_leap' => 10,
+        ],
+        [
+            'period_number' => 6,
+            // Gregorian Common
+            'month_from' => 6,
+            'day_from' => 1,
+            'month_to' => 6,
+            'day_to' => 30,
+            // Gregorian Leap
+            'month_from_leap' => 6,
+            'day_from_leap' => 1,
+            'month_to_leap' => 6,
+            'day_to_leap' => 30,
+            // Ethiopian Common
+            'month_from_ethiopian' => 12,
+            'day_from_ethiopian' => 10,
+            'month_to_ethiopian' => 1,
+            'day_to_ethiopian' => 8,
+            // Ethiopian Leap
+            'month_from_ethiopian_leap' => 12,
+            'day_from_ethiopian_leap' => 11,
+            'month_to_ethiopian_leap' => 1,
+            'day_to_ethiopian_leap' => 9,
+        ],
+        [
+            'period_number' => 7,
+            // Gregorian Common
+            'month_from' => 7,
+            'day_from' => 1,
+            'month_to' => 7,
+            'day_to' => 31,
+            // Gregorian Leap
+            'month_from_leap' => 7,
+            'day_from_leap' => 1,
+            'month_to_leap' => 7,
+            'day_to_leap' => 31,
+            // Ethiopian Common
+            'month_from_ethiopian' => 1,
+            'day_from_ethiopian' => 9,
+            'month_to_ethiopian' => 2,
+            'day_to_ethiopian' => 7,
+            // Ethiopian Leap
+            'month_from_ethiopian_leap' => 1,
+            'day_from_ethiopian_leap' => 10,
+            'month_to_ethiopian_leap' => 2,
+            'day_to_ethiopian_leap' => 8,
+        ],
+        [
+            'period_number' => 8,
+            // Gregorian Common
+            'month_from' => 8,
+            'day_from' => 1,
+            'month_to' => 8,
+            'day_to' => 31,
+            // Gregorian Leap
+            'month_from_leap' => 8,
+            'day_from_leap' => 1,
+            'month_to_leap' => 8,
+            'day_to_leap' => 31,
+            // Ethiopian Common
+            'month_from_ethiopian' => 2,
+            'day_from_ethiopian' => 8,
+            'month_to_ethiopian' => 3,
+            'day_to_ethiopian' => 9,
+            // Ethiopian Leap
+            'month_from_ethiopian_leap' => 2,
+            'day_from_ethiopian_leap' => 9,
+            'month_to_ethiopian_leap' => 3,
+            'day_to_ethiopian_leap' => 9,
+        ],
+        [
+            'period_number' => 9,
+            // Gregorian Common
+            'month_from' => 9,
+            'day_from' => 1,
+            'month_to' => 9,
+            'day_to' => 30,
+            // Gregorian Leap
+            'month_from_leap' => 9,
+            'day_from_leap' => 1,
+            'month_to_leap' => 9,
+            'day_to_leap' => 30,
+            // Ethiopian Common
+            'month_from_ethiopian' => 3,
+            'day_from_ethiopian' => 10,
+            'month_to_ethiopian' => 4,
+            'day_to_ethiopian' => 8,
+            // Ethiopian Leap
+            'month_from_ethiopian_leap' => 3,
+            'day_from_ethiopian_leap' => 10,
+            'month_to_ethiopian_leap' => 4,
+            'day_to_ethiopian_leap' => 8,
+        ],
+        [
+            'period_number' => 10,
+            // Gregorian Common
+            'month_from' => 10,
+            'day_from' => 1,
+            'month_to' => 10,
+            'day_to' => 31,
+            // Gregorian Leap
+            'month_from_leap' => 10,
+            'day_from_leap' => 1,
+            'month_to_leap' => 10,
+            'day_to_leap' => 31,
+            // Ethiopian Common
+            'month_from_ethiopian' => 4,
+            'day_from_ethiopian' => 9,
+            'month_to_ethiopian' => 5,
+            'day_to_ethiopian' => 8,
+            // Ethiopian Leap
+            'month_from_ethiopian_leap' => 4,
+            'day_from_ethiopian_leap' => 9,
+            'month_to_ethiopian_leap' => 5,
+            'day_to_ethiopian_leap' => 8,
+        ],
+        [
+            'period_number' => 11,
+            // Gregorian Common
+            'month_from' => 11,
+            'day_from' => 1,
+            'month_to' => 11,
+            'day_to' => 30,
+            // Gregorian Leap
+            'month_from_leap' => 11,
+            'day_from_leap' => 1,
+            'month_to_leap' => 11,
+            'day_to_leap' => 30,
+            // Ethiopian Common
+            'month_from_ethiopian' => 5,
+            'day_from_ethiopian' => 9,
+            'month_to_ethiopian' => 6,
+            'day_to_ethiopian' => 7,
+            // Ethiopian Leap
+            'month_from_ethiopian_leap' => 5,
+            'day_from_ethiopian_leap' => 9,
+            'month_to_ethiopian_leap' => 6,
+            'day_to_ethiopian_leap' => 7,
+        ],
+        [
+            'period_number' => 12,
+            // Gregorian Common
+            'month_from' => 12,
+            'day_from' => 1,
+            'month_to' => 12,
+            'day_to' => 31,
+            // Gregorian Leap
+            'month_from_leap' => 12,
+            'day_from_leap' => 1,
+            'month_to_leap' => 12,
+            'day_to_leap' => 31,
+            // Ethiopian Common
+            'month_from_ethiopian' => 6,
+            'day_from_ethiopian' => 8,
+            'month_to_ethiopian' => 7,
+            'day_to_ethiopian' => 7,
+            // Ethiopian Leap
+            'month_from_ethiopian_leap' => 6,
+            'day_from_ethiopian_leap' => 8,
+            'month_to_ethiopian_leap' => 7,
+            'day_to_ethiopian_leap' => 7,
+        ],
+    ];
+
+    public function handle($accounting_system_id, $calendar_type, $year, $accounting_system_user_id)
+    {
+        $isLeapYear = $this->isLeapYear($calendar_type, $year);
+        $periods = [];
+
+        if($isLeapYear && $calendar_type == 'gregorian') {
+            $periods = $this->generateGregorianLeapYearPeriods($accounting_system_id, $year, $accounting_system_user_id);
+        }
+        else if($isLeapYear && $calendar_type == 'ethiopian') {
+            $periods = $this->generateEthiopianLeapYearPeriods($accounting_system_id, $year, $accounting_system_user_id);
+        }
+        else if(!$isLeapYear && $calendar_type == 'gregorian') {
+            $periods = $this->generateGregorianCommonYearPeriods($accounting_system_id, $year, $accounting_system_user_id);
+        }
+        else if(!$isLeapYear && $calendar_type == 'ethiopian') {
+            $periods = $this->generateEthiopianCommonYearPeriods($accounting_system_id, $year, $accounting_system_user_id);
+        }
+
+        DB::table('accounting_periods')->insert($periods);
+    }
+
+    private function isLeapYear($calendar_type, $year)
+    {
+        if ($calendar_type == 'ethiopian') {
+            $year += 8;  
+        } 
+
+        return $year % 4 == 0 && ($year % 100 != 0 || $year % 400 == 0);
+    }
+
+    private function generateGregorianLeapYearPeriods($accounting_system_id, $year, $accounting_system_user_id)
+    {
+        $periods = [];
+
+        for($i = 0; $i < count($this->accounting_periods_template); $i++)
+        {
+            $periods[] = [
+                'accounting_system_id' => $accounting_system_id,
+                'accounting_system_user_id' => $accounting_system_user_id,
+                'period_number' => $this->accounting_periods_template[$i]['period_number'],
+                'date_from' => "{$year}-{$this->accounting_periods_template[$i]['month_from_leap']}-{$this->accounting_periods_template[$i]['day_from_leap']}",
+                'date_to' => "{$year}-{$this->accounting_periods_template[$i]['month_to_leap']}-{$this->accounting_periods_template[$i]['day_to_leap']}",
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]; 
+        }
+
+        return $periods;
+    }
+
+    private function generateGregorianCommonYearPeriods($accounting_system_id, $year, $accounting_system_user_id)
+    {
+        $periods = [];
+
+        for($i = 0; $i < count($this->accounting_periods_template); $i++)
+        {
+            $periods[] = [
+                'accounting_system_id' => $accounting_system_id,
+                'accounting_system_user_id' => $accounting_system_user_id,
+                'period_number' => $this->accounting_periods_template[$i]['period_number'],
+                'date_from' => "{$year}-{$this->accounting_periods_template[$i]['month_from']}-{$this->accounting_periods_template[$i]['day_from']}",
+                'date_to' => "{$year}-{$this->accounting_periods_template[$i]['month_to']}-{$this->accounting_periods_template[$i]['day_to']}",
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]; 
+        }
+
+        return $periods;
+    }
+
+    private function generateEthiopianLeapYearPeriods($accounting_system_id, $year, $accounting_system_user_id)
+    {
+        $periods = [];
+        $year += 7;
+
+        for($i = 0; $i < count($this->accounting_periods_template); $i++)
+        {
+            $periods[] = [
+                'accounting_system_id' => $accounting_system_id,
+                'accounting_system_user_id' => $accounting_system_user_id,
+                'period_number' => $this->accounting_periods_template[$i]['period_number'],
+                'date_from' => "{$year}-{$this->accounting_periods_template[$i]['month_from_ethiopian_leap']}-{$this->accounting_periods_template[$i]['day_from_ethiopian_leap']}",
+                'date_to' => ($i == 5 ? ++$year : $year) + "-{$this->accounting_periods_template[$i]['month_to_ethiopian_leap']}-{$this->accounting_periods_template[$i]['day_to_ethiopian_leap']}",
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]; 
+        }
+
+        return $periods;
+    }
+
+    private function generateEthiopianCommonYearPeriods($accounting_system_id, $year, $accounting_system_user_id)
+    {
+        $periods = [];
+        $year += 7;
+
+        for($i = 0; $i < count($this->accounting_periods_template); $i++)
+        {
+            $periods[] = [
+                'accounting_system_id' => $accounting_system_id,
+                'accounting_system_user_id' => $accounting_system_user_id,
+                'period_number' => $this->accounting_periods_template[$i]['period_number'],
+                'date_from' => "{$year}-{$this->accounting_periods_template[$i]['month_from_ethiopian']}-{$this->accounting_periods_template[$i]['day_from_ethiopian']}",
+                'date_to' => ($i == 5 ? ++$year : $year) . "-{$this->accounting_periods_template[$i]['month_to_ethiopian']}-{$this->accounting_periods_template[$i]['day_to_ethiopian']}",
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]; 
+        }
+
+        return $periods;
+    }
+
+
+}

--- a/app/Models/AccountingSystem.php
+++ b/app/Models/AccountingSystem.php
@@ -11,6 +11,8 @@ class AccountingSystem extends Model
 
     protected $fillable = [
         'subscription_id',
+        'calendar_type',
+        'accounting_year',
         'name',
         'address',
         'po_box',

--- a/app/Models/Settings/ChartOfAccounts/AccountingPeriods.php
+++ b/app/Models/Settings/ChartOfAccounts/AccountingPeriods.php
@@ -11,6 +11,7 @@ class AccountingPeriods extends Model
 
     protected $fillable = [
         'accounting_system_id',
+        'accounting_system_user_id',
         'period_number',
         'date_from',
         'date_to',

--- a/database/migrations/2022_02_04_015104_create_accounting_systems_table.php
+++ b/database/migrations/2022_02_04_015104_create_accounting_systems_table.php
@@ -20,10 +20,7 @@ class CreateAccountingSystemsTable extends Migration
                 'gregorian',
                 'ethiopian',
             ]);
-            $table->enum('calendar_type_view', [
-                'gregorian',
-                'ethiopian',
-            ]);
+            $table->integer('accounting_year');
             $table->string('name');
             $table->mediumText('address');
             $table->string('po_box')->nullable();

--- a/database/migrations/2022_03_12_135619_create_accounting_periods_table.php
+++ b/database/migrations/2022_03_12_135619_create_accounting_periods_table.php
@@ -16,11 +16,12 @@ class CreateAccountingPeriodsTable extends Migration
         Schema::create('accounting_periods', function (Blueprint $table) {
             $table->id();
             $table->foreignId('accounting_system_id')->constrained();
+            $table->foreignId('accounting_system_user_id')->constrained();
             $table->integer('period_number');
             $table->date('date_from');
             $table->date('date_to');
-            $table->string('date_from_ethiopian');
-            $table->string('date_to_ethiopian');
+            $table->string('date_from_ethiopian')->nullable();
+            $table->string('date_to_ethiopian')->nullable();
             $table->timestamps();
         });
     }

--- a/database/seeders/UserTableSeeder.php
+++ b/database/seeders/UserTableSeeder.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str; 
+use App\Actions\GenerateAccountingPeriods;
+
 class UserTableSeeder extends Seeder
 {
     /**
@@ -16,7 +18,7 @@ class UserTableSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('users')->insert([
+        $users = [
             [
                 'email' => 'admin@email.com',
                 'password' => Hash::make('test'),
@@ -39,13 +41,13 @@ class UserTableSeeder extends Seeder
                 'created_at' => now(),
                 'updated_at' => now(),
             ],
-        ]);
+        ];
 
-        DB::table('accounting_systems')->insert([
+        $accounting_systems = [
             [
                 'name' => 'Test Accounting System',
                 'calendar_type' => 'gregorian',
-                'calendar_type_view' => 'gregorian',
+                'accounting_year' => 2022,
                 'address' => 'Cebu',
                 'city' => 'Cebu City',
                 'mobile_number' => '09123456789',
@@ -59,8 +61,8 @@ class UserTableSeeder extends Seeder
             ],
             [
                 'name' => 'Test Accounting System 2',
-                'calendar_type' => 'gregorian',
-                'calendar_type_view' => 'gregorian',
+                'calendar_type' => 'ethiopian',
+                'accounting_year' => 2014,
                 'address' => 'Cebu',
                 'city' => 'Cebu City',
                 'mobile_number' => '09123456789',
@@ -75,7 +77,7 @@ class UserTableSeeder extends Seeder
             [
                 'name' => 'Test Accounting System 3',
                 'calendar_type' => 'gregorian',
-                'calendar_type_view' => 'gregorian',
+                'accounting_year' => 2022,
                 'address' => 'Cebu',
                 'city' => 'Cebu City',
                 'mobile_number' => '09123456789',
@@ -87,9 +89,9 @@ class UserTableSeeder extends Seeder
                 'created_at' => now(),
                 'updated_at' => now(),
             ],
-        ]);
+        ];
 
-        DB::table('accounting_system_users')->insert([
+        $accounting_system_users = [
             [
                 'accounting_system_id' => 1,
                 'user_id' => 1,
@@ -105,9 +107,9 @@ class UserTableSeeder extends Seeder
                 'user_id' => 2,
                 'role' => 'admin',
             ]
-        ]);
+        ];
 
-        DB::table('journal_entries')->insert([
+        $journal_entries = [
             [
                 'date' => '2022-01-01',
                 'notes' => 'Beginning Balance',
@@ -123,71 +125,21 @@ class UserTableSeeder extends Seeder
                 'notes' => 'Beginning Balance',
                 'accounting_system_id' => 3,
             ],
-        ]);
+        ];
+
+        DB::table('users')->insert($users);
+        DB::table('accounting_systems')->insert($accounting_systems);
+        DB::table('accounting_system_users')->insert($accounting_system_users);
+        DB::table('journal_entries')->insert($journal_entries);
 
         // Loop accounting systems
-        for($i = 1; $i <= 3; $i++)
+        for($i = 0; $i < count($accounting_systems); $i++)
         {
-            // Setup accounting period for each accounting system
-            $accounting_period[] = [
-                'accounting_system_id' => $i,
-                'period_number' => 1,
-                'date_from' => '2022-05-01',
-                'date_to' => '2022-05-31',
-                'date_from_ethiopian' => '2014-08-23',
-                'date_to_ethiopian' => '2014-09-23',
-                'created_at' => now(),
-                'updated_at' => now(),
-            ];
-
-            // Loop months
-            for($j = 1; $j <= 12; $j++)
-            {
-                // Gregorian Months
-                switch($j)
-                {
-                    case 1:     $day = 31; $day_leap = 31; break;
-                    case 2:     $day = 28; $day_leap = 29; break;
-                    case 3:     $day = 31; $day_leap = 31; break;
-                    case 4:     $day = 30; $day_leap = 30; break;
-                    case 5:     $day = 31; $day_leap = 31; break;
-                    case 6:     $day = 30; $day_leap = 30; break;
-                    case 7:     $day = 31; $day_leap = 31; break;
-                    case 8:     $day = 31; $day_leap = 31; break;
-                    case 9:     $day = 30; $day_leap = 30; break;
-                    case 10:    $day = 31; $day_leap = 31; break;
-                    case 11:    $day = 30; $day_leap = 30; break;
-                    case 12:    $day = 31; $day_leap = 31; break;
-                }
-
-                // Create period settings row
-                $period_settings[] = [
-                    'accounting_system_id' => $i,
-                    // Date From
-                    'month_from' => $j,
-                    'day_from' => 1,
-                    // Date To
-                    'month_to' => $j,
-                    'day_to' => $day,
-                    // Date From Leap
-                    'month_from_leap' => $j,
-                    'day_from_leap' => 1,
-                    // Date To Leap
-                    'month_to_leap' => $j,
-                    'day_to_leap' => $day_leap,
-                    // TODO: Ethiopian Date Support Later
-                    // User ID
-                    'accounting_system_user_id' => $i,
-                    'created_at' => now(),
-                    'updated_at' => now(),
-                ];
-            }
+            GenerateAccountingPeriods::run($i+1, 
+                $accounting_systems[$i]['calendar_type'],
+                $accounting_systems[$i]['accounting_year'],
+                $i+1);
         }
-
-
-        DB::table('period_settings')->insert($period_settings);
-
-        DB::table('accounting_periods')->insert($accounting_period);
 
         // Loop users
         for($i = 1; $i <= 3; $i++)

--- a/resources/views/template/navbar.blade.php
+++ b/resources/views/template/navbar.blade.php
@@ -4,8 +4,7 @@
 
     $accounting_system = \App\Models\AccountingSystem::find(session('accounting_system_id'));
     $accounting_system_count = \App\Models\AccountingSystemUser::where('user_id', Auth::user()->id)->count();
-    $accounting_period = \App\Models\Settings\ChartOfAccounts\AccountingPeriods::find(session('accounting_period_id'));
-    $accounting_period_year = \Carbon\Carbon::parse($accounting_period->date_from);
+    $accounting_periods = \App\Models\Settings\ChartOfAccounts\AccountingPeriods::where('accounting_system_id', session('accounting_system_id'))->get();
 @endphp
  
  <!-- Sidebar -->
@@ -143,8 +142,17 @@
 
                     <!-- Topbar Accounting System Name & Year -->
                     <div>
-                        <strong>{{ date('Y') }} - {{ $accounting_system->name }}</strong><br>
-                        <small><strong>{{ "Accounting Period # {$accounting_period->period_number}" }}</strong> | {{ $accounting_period_year->format('M Y') }}</small>
+                        <strong>
+                            {{ $accounting_system->accounting_year}}
+                             - 
+                            {{ $accounting_system->name }}</strong><br>
+                        <small>
+                            
+                            {{ \Carbon\Carbon::parse($accounting_periods[0]->date_from)->format('Y-m-d') }}
+                             - 
+                             {{ \Carbon\Carbon::parse($accounting_periods[11]->date_to)->format('Y-m-d') }}
+                            
+                        </small>
                     </div>
 
                     <!-- Topbar Navbar -->


### PR DESCRIPTION
See the difference of dates between the rows 1-12 and 13-24 (Gregorian and Ethiopian respectively)
![image](https://user-images.githubusercontent.com/32955000/171078457-8fb550ff-1c55-446c-b750-635e27203d2e.png)

The UI is also enhanced accordingly to show Ethiopian Year if the `calendar_type` is set to `ethiopian`. Otherwise, show `gregorian`.
![image](https://user-images.githubusercontent.com/32955000/171078565-17e29a9c-f6a1-4950-ba29-36115b63a38a.png)
![image](https://user-images.githubusercontent.com/32955000/171078586-423c4faa-7743-4127-a2f1-2f0ef6e10bcf.png)

You may now generate the Accounting Periods by calling
`\App\Actions\GenerateAccountingPeriods::run($accounting_system_id, $calendar_type, $year, $accounting_system_user_id)`.

Pre-requisites to call this function:
- Created an accounting system.
- Created an accounting system user. (Next to accounting system)
- The user selected a calendar type (`gregorian`/`ethiopian`) and an accounting year.

This may be the flow when registering an accounting system to the database.
For guidance, Sir @justinmanigo .