### PR TITLE
Implement `Settings > Defaults`

### DIFF
--- a/app/Http/Controllers/Settings/ChartOfAccountsController.php
+++ b/app/Http/Controllers/Settings/ChartOfAccountsController.php
@@ -212,6 +212,7 @@ class ChartOfAccountsController extends Controller
         $coa = ChartOfAccounts::select(
                 'chart_of_accounts.id as value',
                 'chart_of_accounts.chart_of_account_no',
+                DB::raw('CONCAT(chart_of_accounts.chart_of_account_no, " - ", chart_of_accounts.account_name) as label'),
                 'chart_of_accounts.account_name',
                 // 'chart_of_account_categories.id',
                 'chart_of_account_categories.category',

--- a/app/Http/Controllers/Settings/ChartOfAccountsController.php
+++ b/app/Http/Controllers/Settings/ChartOfAccountsController.php
@@ -207,9 +207,9 @@ class ChartOfAccountsController extends Controller
 
     /**====================== */
 
-    function ajaxSearchCOA($query)
+    function ajaxSearchCOA($query = null)
     {
-        return ChartOfAccounts::select(
+        $coa = ChartOfAccounts::select(
                 'chart_of_accounts.id as value',
                 'chart_of_accounts.chart_of_account_no',
                 'chart_of_accounts.account_name',
@@ -218,11 +218,15 @@ class ChartOfAccountsController extends Controller
                 'chart_of_account_categories.type',
                 'chart_of_account_categories.normal_balance',
             )
-            ->leftJoin('chart_of_account_categories', 'chart_of_account_categories.id', '=', 'chart_of_accounts.chart_of_account_category_id')
-            ->where('chart_of_accounts.chart_of_account_no', 'LIKE', '%' . $query . '%')
-            ->orWhere('chart_of_account_categories.category', 'LIKE', '%' . $query . '%')
-            ->orWhere('chart_of_account_categories.type', 'LIKE', '%' . $query . '%')
-            ->get();
+            ->leftJoin('chart_of_account_categories', 'chart_of_account_categories.id', '=', 'chart_of_accounts.chart_of_account_category_id');
+
+        if($query) {
+            $coa->where('chart_of_accounts.chart_of_account_no', 'LIKE', '%' . $query . '%')
+                ->orWhere('chart_of_account_categories.category', 'LIKE', '%' . $query . '%')
+                ->orWhere('chart_of_account_categories.type', 'LIKE', '%' . $query . '%');
+        }
+
+        return $coa->limit(5)->get();
     }
 
     function ajaxGetCOAForBeginningBalance()

--- a/app/Http/Controllers/Settings/ChartOfAccountsController.php
+++ b/app/Http/Controllers/Settings/ChartOfAccountsController.php
@@ -227,7 +227,7 @@ class ChartOfAccountsController extends Controller
                 ->orWhere('chart_of_account_categories.type', 'LIKE', '%' . $query . '%');
         }
 
-        return $coa->limit(5)->get();
+        return $coa->get();
     }
 
     function ajaxGetCOAForBeginningBalance()

--- a/app/Http/Controllers/Settings/DefaultsController.php
+++ b/app/Http/Controllers/Settings/DefaultsController.php
@@ -4,37 +4,69 @@ namespace App\Http\Controllers\Settings;
 
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\Defaults\UpdateAdvanceReceiptDefaultsRequest;
+use App\Http\Requests\Settings\Defaults\UpdateBillDefaultsRequest;
+use App\Http\Requests\Settings\Defaults\UpdateCreditReceiptDefaultsRequest;
+use App\Http\Requests\Settings\Defaults\UpdatePaymentDefaultsRequest;
+use App\Http\Requests\Settings\Defaults\UpdateReceiptDefaultsRequest;
+use App\Models\AccountingSystem;
 
 class DefaultsController extends Controller
 {
-    // TODO: Index
     public function index()
     {
         return view('settings.defaults.index');
     }
 
-    public function updateReceipts(Request $request)
+    public function updateReceipts(UpdateReceiptDefaultsRequest $request)
     {
-        //
+        return AccountingSystem::find($request->accounting_system_id)->update([
+            'receipt_cash_on_hand' => $request->receipt_cash_on_hand,
+            'receipt_vat_payable' => $request->receipt_vat_payable,
+            'receipt_sales' => $request->receipt_sales,
+            'receipt_account_receivable' => $request->receipt_account_receivable,
+            'receipt_sales_discount' => $request->receipt_sales_discount,
+            'receipt_withholding' => $request->receipt_withholding,
+        ]);
     }
 
-    public function updateAdvanceReceipts(Request $request)
+    public function updateAdvanceReceipts(UpdateAdvanceReceiptDefaultsRequest $request)
     {
-        //
+        return AccountingSystem::find($request->accounting_system_id)->update([
+            'advance_receipt_cash_on_hand' => $request->advance_receipt_cash_on_hand,
+            'advance_receipt_advance_payment' => $request->advance_receipt_advance_payment,
+        ]);
     }
 
-    public function updateCreditReceipts(Request $request)
+    public function updateCreditReceipts(UpdateCreditReceiptDefaultsRequest $request)
     {
-        //
+        return AccountingSystem::find($request->accounting_system_id)->update([
+            'credit_receipt_cash_on_hand' => $request->credit_receipt_cash_on_hand,
+            'credit_receipt_credit_payment' => $request->credit_receipt_credit_payment,
+        ]);
     }
 
-    public function updateBills(Request $request)
+    public function updateBills(UpdateBillDefaultsRequest $request)
     {
-        //
+        return AccountingSystem::find($request->accounting_system_id)->update([
+            'bill_cash_on_hand' => $request->bill_cash_on_hand,
+            'bill_items_for_sale' => $request->bill_items_for_sale,
+            'bill_freight_charge_expense' => $request->bill_freight_charge_expense,
+            'bill_vat_receivable' => $request->bill_vat_receivable,
+            'bill_account_payable' => $request->bill_account_payable,
+            'bill_withholding' => $request->bill_withholding,
+        ]);
     }
 
-    public function updatePayments(Request $request)
+    public function updatePayments(UpdatePaymentDefaultsRequest $request)
     {
-        //
+        return AccountingSystem::find($request->accounting_system_id)->update([
+            'payment_cash_on_hand' => $request->payment_cash_on_hand,
+            'payment_vat_receivable' => $request->payment_vat_receivable,
+            'payment_account_payable' => $request->payment_account_payable,
+            'payment_withholding' => $request->payment_withholding,
+            'payment_salary_payable' => $request->payment_salary_payable,
+            'payment_commission_payment' => $request->payment_commission_payment,
+        ]);
     }
 }

--- a/app/Http/Controllers/Settings/DefaultsController.php
+++ b/app/Http/Controllers/Settings/DefaultsController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+
+class DefaultsController extends Controller
+{
+    // TODO: Index
+    public function index()
+    {
+        return view('settings.defaults.index');
+    }
+
+    public function updateReceipts(Request $request)
+    {
+        //
+    }
+
+    public function updateAdvanceReceipts(Request $request)
+    {
+        //
+    }
+
+    public function updateCreditReceipts(Request $request)
+    {
+        //
+    }
+
+    public function updateBills(Request $request)
+    {
+        //
+    }
+
+    public function updatePayments(Request $request)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/Settings/DefaultsController.php
+++ b/app/Http/Controllers/Settings/DefaultsController.php
@@ -18,6 +18,39 @@ class DefaultsController extends Controller
         return view('settings.defaults.index');
     }
 
+    public function getDefaults()
+    {
+        $accounting_system = AccountingSystem::find(session('accounting_system_id'));
+        $accounting_system->receiptCashOnHand;
+        $accounting_system->receiptVatPayable;
+        $accounting_system->receiptSales;
+        $accounting_system->receiptAccountReceivable;
+        $accounting_system->receiptSalesDiscount;
+        $accounting_system->receiptWithholding;
+
+        $accounting_system->advanceReceiptCashOnHand;
+        $accounting_system->advanceReceiptAdvancePayment;
+
+        $accounting_system->creditReceiptCashOnHand;
+        $accounting_system->creditReceiptAccountReceivable;
+
+        $accounting_system->billCashOnHand;
+        $accounting_system->billItemsForSale;
+        $accounting_system->billFreightChargeExpense;
+        $accounting_system->billVatReceivable;
+        $accounting_system->billAccountPayable;
+        $accounting_system->billWithholding;
+
+        $accounting_system->paymentCashOnHand;
+        $accounting_system->paymentVatReceivable;
+        $accounting_system->paymentAccountPayable;
+        $accounting_system->paymentWithholding;
+        $accounting_system->paymentSalaryPayable;
+        $accounting_system->paymentCommissionPayment;
+
+        return $accounting_system;
+    }
+
     public function updateReceipts(UpdateReceiptDefaultsRequest $request)
     {
         return AccountingSystem::find($request->accounting_system_id)->update([

--- a/app/Http/Requests/Settings/Defaults/UpdateAdvanceReceiptDefaultsRequest.php
+++ b/app/Http/Requests/Settings/Defaults/UpdateAdvanceReceiptDefaultsRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Settings\Defaults;
+
+use App\Actions\DecodeTagifyField;
+use App\Http\Requests\Api\FormRequest;
+
+class UpdateAdvanceReceiptDefaultsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'accounting_system_id' => session('accounting_system_id'),
+            'advance_receipt_cash_on_hand' => $this->advance_receipt_cash_on_hand ? DecodeTagifyField::run($this->advance_receipt_cash_on_hand)->value : null,
+            'advance_receipt_advance_payment' => $this->advance_receipt_advance_payment ? DecodeTagifyField::run($this->advance_receipt_advance_payment)->value : null,
+        ]);
+    }
+}

--- a/app/Http/Requests/Settings/Defaults/UpdateBillDefaultsRequest.php
+++ b/app/Http/Requests/Settings/Defaults/UpdateBillDefaultsRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Settings\Defaults;
+
+use App\Actions\DecodeTagifyField;
+use App\Http\Requests\Api\FormRequest;
+
+class UpdateBillDefaultsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'accounting_system_id' => session('accounting_system_id'),
+            'bill_cash_on_hand' => $this->bill_cash_on_hand ? DecodeTagifyField::run($this->bill_cash_on_hand)->value : null,
+            'bill_items_for_sale' => $this->bill_items_for_sale ? DecodeTagifyField::run($this->bill_items_for_sale)->value : null,
+            'bill_freight_charge_expense' => $this->bill_freight_charge_expense ? DecodeTagifyField::run($this->bill_freight_charge_expense)->value : null,
+            'bill_vat_receivable' => $this->bill_vat_receivable ? DecodeTagifyField::run($this->bill_vat_receivable)->value : null,
+            'bill_account_payable' => $this->bill_account_payable ? DecodeTagifyField::run($this->bill_account_payable)->value : null,
+            'bill_withholding' => $this->bill_withholding ? DecodeTagifyField::run($this->bill_withholding)->value : null,
+        ]);
+    }
+}

--- a/app/Http/Requests/Settings/Defaults/UpdateCreditReceiptDefaultsRequest.php
+++ b/app/Http/Requests/Settings/Defaults/UpdateCreditReceiptDefaultsRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Settings\Defaults;
+
+use App\Actions\DecodeTagifyField;
+use App\Http\Requests\Api\FormRequest;
+
+class UpdateCreditReceiptDefaultsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'accounting_system_id' => session('accounting_system_id'),
+            'credit_receipt_cash_on_hand' => $this->credit_receipt_cash_on_hand ? DecodeTagifyField::run($this->credit_receipt_cash_on_hand)->value : null,
+            'credit_receipt_account_receivable' => $this->credit_receipt_account_receivable ? DecodeTagifyField::run($this->credit_receipt_account_receivable)->value : null,
+        ]);
+    }
+}

--- a/app/Http/Requests/Settings/Defaults/UpdatePaymentDefaultsRequest.php
+++ b/app/Http/Requests/Settings/Defaults/UpdatePaymentDefaultsRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Settings\Defaults;
+
+use App\Actions\DecodeTagifyField;
+use App\Http\Requests\Api\FormRequest;
+
+class UpdatePaymentDefaultsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'accounting_system_id' => session('accounting_system_id'),
+            'payment_cash_on_hand' => $this->payment_cash_on_hand ? DecodeTagifyField::run($this->payment_cash_on_hand)->value : null,
+            'payment_vat_receivable' => $this->payment_vat_receivable ? DecodeTagifyField::run($this->payment_vat_receivable)->value : null,
+            'payment_account_payable' => $this->payment_account_payable ? DecodeTagifyField::run($this->payment_account_payable)->value : null,
+            'payment_withholding' => $this->payment_withholding ? DecodeTagifyField::run($this->payment_withholding)->value : null,
+            'payment_salary_payable' => $this->payment_salary_payable ? DecodeTagifyField::run($this->payment_salary_payable)->value : null,
+            'payment_commission_payment' => $this->payment_commission_payment ? DecodeTagifyField::run($this->payment_commission_payment)->value : null,
+        ]);
+    }
+}

--- a/app/Http/Requests/Settings/Defaults/UpdateReceiptDefaultsRequest.php
+++ b/app/Http/Requests/Settings/Defaults/UpdateReceiptDefaultsRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests\Settings\Defaults;
+
+use App\Actions\DecodeTagifyField;
+use App\Http\Requests\Api\FormRequest;
+
+class UpdateReceiptDefaultsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'accounting_system_id' => session('accounting_system_id'),
+            'receipt_cash_on_hand' => $this->receipt_cash_on_hand ? DecodeTagifyField::run($this->receipt_cash_on_hand)->value : null,
+            'receipt_vat_payable' => $this->receipt_vat_payable ? DecodeTagifyField::run($this->receipt_vat_payable)->value : null,
+            'receipt_sales' => $this->receipt_sales ? DecodeTagifyField::run($this->receipt_sales)->value : null,
+            'receipt_account_receivable' => $this->receipt_account_receivable ? DecodeTagifyField::run($this->receipt_account_receivable)->value : null,
+            'receipt_sales_discount' => $this->receipt_sales_discount ? DecodeTagifyField::run($this->receipt_sales_discount)->value : null,
+            'receipt_withholding' => $this->receipt_withholding ? DecodeTagifyField::run($this->receipt_withholding)->value : null,
+            // 'receipt_vat_payable' => DecodeTagifyField::run($this->receipt_vat_payable),
+            // 'receipt_sales' => DecodeTagifyField::run($this->receipt_sales),
+            // 'receipt_account_receivable' => DecodeTagifyField::run($this->receipt_account_receivable),
+            // 'receipt_sales_discount' => DecodeTagifyField::run($this->receipt_sales_discount),
+            // 'receipt_withholding' => DecodeTagifyField::run($this->receipt_withholding),
+        ]);
+    }
+}

--- a/app/Models/AccountingSystem.php
+++ b/app/Models/AccountingSystem.php
@@ -36,25 +36,32 @@ class AccountingSystem extends Model
         'settings_inventory_type',
 
         // Settings Defaults
-        'receipt_default_cash_on_hand',
-        'receipt_default_vat_payable',
-        'receipt_default_sales',
-        'receipt_default_account_receivable',
-        'receipt_default_sales_discount',
-        'receipt_default_withholding',
+        'receipt_cash_on_hand',
+        'receipt_vat_payable',
+        'receipt_sales',
+        'receipt_account_receivable',
+        'receipt_sales_discount',
+        'receipt_withholding',
 
-        'advance_receipt_default_cash_on_hand',
-        'advance_receipt_default_advance_payment',
+        'advance_receipt_cash_on_hand',
+        'advance_receipt_advance_payment',
 
-        'credit_receipt_default_cash_on_hand',
-        'credit_receipt_default_account_receivable',
+        'credit_receipt_cash_on_hand',
+        'credit_receipt_account_receivable',
 
-        'bill_default_cash_on_hand',
-        'bill_default_items_for_sale',
-        'bill_default_freight_charge_expense',
-        'bill_default_vat_receivable',
-        'bill_default_account_payable',
-        'bill_default_withholding',
+        'bill_cash_on_hand',
+        'bill_items_for_sale',
+        'bill_freight_charge_expense',
+        'bill_vat_receivable',
+        'bill_account_payable',
+        'bill_withholding',
+
+        'payment_cash_on_hand',
+        'payment_vat_receivable',
+        'payment_account_payable',
+        'payment_withholding',
+        'payment_salary_payable',
+        'payment_commission_payment',
 
     ];
 

--- a/app/Models/AccountingSystem.php
+++ b/app/Models/AccountingSystem.php
@@ -10,6 +10,7 @@ class AccountingSystem extends Model
     use HasFactory;
 
     protected $fillable = [
+        // Main Fields
         'subscription_id',
         'calendar_type',
         'accounting_year',
@@ -30,7 +31,31 @@ class AccountingSystem extends Model
         'contact_person_position',
         'contact_person_mobile_number',
         'business_type',
+
+        // Settings Inventory Type
         'settings_inventory_type',
+
+        // Settings Defaults
+        'receipt_default_cash_on_hand',
+        'receipt_default_vat_payable',
+        'receipt_default_sales',
+        'receipt_default_account_receivable',
+        'receipt_default_sales_discount',
+        'receipt_default_withholding',
+
+        'advance_receipt_default_cash_on_hand',
+        'advance_receipt_default_advance_payment',
+
+        'credit_receipt_default_cash_on_hand',
+        'credit_receipt_default_account_receivable',
+
+        'bill_default_cash_on_hand',
+        'bill_default_items_for_sale',
+        'bill_default_freight_charge_expense',
+        'bill_default_vat_receivable',
+        'bill_default_account_payable',
+        'bill_default_withholding',
+
     ];
 
     public function subscription()

--- a/app/Models/AccountingSystem.php
+++ b/app/Models/AccountingSystem.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Settings\ChartOfAccounts\ChartOfAccounts;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -73,5 +74,118 @@ class AccountingSystem extends Model
     public function accountingSystemUsers()
     {
         return $this->hasMany(AccountingSystemUser::class);
+    }
+
+    /**
+     * Relationships from defaults
+     */
+    public function receiptCashOnHand()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'receipt_cash_on_hand');
+    }
+
+    public function receiptVatPayable()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'receipt_vat_payable');
+    }
+
+    public function receiptSales()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'receipt_sales');
+    }
+
+    public function receiptAccountReceivable()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'receipt_account_receivable');
+    }
+
+    public function receiptSalesDiscount()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'receipt_sales_discount');
+    }
+
+    public function receiptWithholding()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'receipt_withholding');
+    }
+
+    public function advanceReceiptCashOnHand()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'advance_receipt_cash_on_hand');
+    }
+
+    public function advanceReceiptAdvancePayment()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'advance_receipt_advance_payment');
+    }
+
+    public function creditReceiptCashOnHand()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'credit_receipt_cash_on_hand');
+    }
+
+    public function creditReceiptAccountReceivable()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'credit_receipt_account_receivable');
+    }
+
+    public function billCashOnHand()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'bill_cash_on_hand');
+    }
+
+    public function billItemsForSale()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'bill_items_for_sale');
+    }
+
+    public function billFreightChargeExpense()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'bill_freight_charge_expense');
+    }
+
+    public function billVatReceivable()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'bill_vat_receivable');
+    }
+
+    public function billAccountPayable()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'bill_account_payable');
+    }
+
+    public function billWithholding()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'bill_withholding');
+    }
+
+    public function paymentCashOnHand()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'payment_cash_on_hand');
+    }
+
+    public function paymentVatReceivable()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'payment_vat_receivable');
+    }
+
+    public function paymentAccountPayable()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'payment_account_payable');
+    }
+
+    public function paymentWithholding()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'payment_withholding');
+    }
+
+    public function paymentSalaryPayable()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'payment_salary_payable');
+    }
+
+    public function paymentCommissionPayment()
+    {
+        return $this->hasOne(ChartOfAccounts::class, 'id', 'payment_commission_payment');
     }
 }

--- a/database/migrations/2022_02_04_015104_create_accounting_systems_table.php
+++ b/database/migrations/2022_02_04_015104_create_accounting_systems_table.php
@@ -14,6 +14,7 @@ class CreateAccountingSystemsTable extends Migration
     public function up()
     {
         Schema::create('accounting_systems', function (Blueprint $table) {
+            // Main Fields
             $table->id();
             $table->foreignId('subscription_id')->nullable()->constrained();
             $table->enum('calendar_type', [
@@ -43,12 +44,14 @@ class CreateAccountingSystemsTable extends Migration
                 'PLC',
                 'Share Company'
             ]);
+            $table->timestamps();
+
+            // Settings Inventory Type
             $table->enum('settings_inventory_type', [
                 'average',
                 'lifo',
                 'fifo',
             ])->default('average');
-            $table->timestamps();
         });
     }
 

--- a/database/migrations/2022_06_11_130227_update_accounting_systems_add_settings_defaults.php
+++ b/database/migrations/2022_06_11_130227_update_accounting_systems_add_settings_defaults.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateAccountingSystemsAddSettingsDefaults extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Update accounting_systems schema
+        Schema::table('accounting_systems', function (Blueprint $table) {
+            // Settings Inventory Type
+            // Settings Defaults
+            $table->foreignId('receipt_cash_on_hand')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('receipt_vat_payable')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('receipt_sales')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('receipt_account_receivable')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('receipt_sales_discount')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('receipt_withholding')->nullable()->references('id')->on('chart_of_accounts');
+
+            $table->foreignId('advance_receipt_cash_on_hand')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('advance_receipt_advance_payment')->nullable()->references('id')->on('chart_of_accounts');
+
+            $table->foreignId('credit_receipt_cash_on_hand')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('credit_receipt_account_receivable')->nullable()->references('id')->on('chart_of_accounts');
+
+            $table->foreignId('bill_cash_on_hand')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('bill_items_for_sale')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('bill_freight_charge_expense')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('bill_vat_receivable')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('bill_account_payable')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('bill_withholding')->nullable()->references('id')->on('chart_of_accounts');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2022_06_11_130227_update_accounting_systems_add_settings_defaults.php
+++ b/database/migrations/2022_06_11_130227_update_accounting_systems_add_settings_defaults.php
@@ -36,6 +36,13 @@ class UpdateAccountingSystemsAddSettingsDefaults extends Migration
             $table->foreignId('bill_vat_receivable')->nullable()->references('id')->on('chart_of_accounts');
             $table->foreignId('bill_account_payable')->nullable()->references('id')->on('chart_of_accounts');
             $table->foreignId('bill_withholding')->nullable()->references('id')->on('chart_of_accounts');
+
+            $table->foreignId('payment_cash_on_hand')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('payment_vat_receivable')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('payment_account_payable')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('payment_withholding')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('payment_salary_payable')->nullable()->references('id')->on('chart_of_accounts');
+            $table->foreignId('payment_commission_payment')->nullable()->references('id')->on('chart_of_accounts');
         });
     }
 

--- a/public/js/ajax-submit-updated.js
+++ b/public/js/ajax-submit-updated.js
@@ -34,7 +34,15 @@ $(".ajax-submit-updated").submit(function(e){
         // Remove query string on currentLink
         currentLink = currentLink.split("?");
         // Redirect using currentLink with new query string
-        window.location.href = `${currentLink[0]}?success=${e.target.dataset.message}`;
+        if(e.target.dataset.noreload != undefined)
+        {
+            $(`#${e.target.id}`).prepend(generateAlert(e.target.dataset.message, "success"));
+        }
+        else
+        {
+            window.location.href = `${currentLink[0]}?success=${e.target.dataset.message}`;
+        }
+
     });
 
     // If request has errors (e.g. validation errors).
@@ -97,4 +105,16 @@ function enableSubmitButtonUpdated(btn) {
 
 function disableSubmitButtonUpdated(btn) {
     btn.attr('disabled', true);
+}
+
+function generateAlert(message, bgColor) {
+    let alert = `
+        <div class="alert alert-${bgColor} alert-dismissible fade show" role="alert">
+            ${message}
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+            </button>
+        </div>
+    `;
+    return alert;
 }

--- a/public/js/settings/defaults/defaults.js
+++ b/public/js/settings/defaults/defaults.js
@@ -39,6 +39,7 @@ request_defaults.always(function() {
     
     request.always(function() {
         tagify_defaults_elms.forEach(function(elm){
+            elm.disabled = false;
             console.log(elm.name);
             if(defaults_data[elm.name] != undefined) {
                 var tagify_defaults = defaults_data[elm.name];

--- a/public/js/settings/defaults/defaults.js
+++ b/public/js/settings/defaults/defaults.js
@@ -1,0 +1,122 @@
+var controller;
+
+var tagify_defaults_elms = document.querySelectorAll('.tagify-defaults');
+var tagify_defaults = [];
+
+var coa_whitelist = [];
+var request = $.ajax({
+    url: '/ajax/settings/coa/search/',
+    type: 'GET',
+    dataType: 'json'
+});
+
+request.done(function(data) {
+    console.log(data);
+    coa_whitelist = data;
+});
+
+request.fail(function(jqXHR, textStatus) {
+    console.log('Request failed: ' + textStatus);
+});
+
+request.always(function() {
+    tagify_defaults_elms.forEach(function(elm){
+
+        var tagify = new Tagify(elm, {
+            tagTextProp: 'label', // very important since a custom template is used with this property as text
+            enforceWhitelist: true,
+            mode : "select",
+            skipInvalid: false, // do not remporarily add invalid tags
+            dropdown: {
+                closeOnSelect: true,
+                enabled: 0,
+                classname: 'customers-list',
+                searchKeys: ['label']  // very important to set by which keys to search for suggesttions when typing
+            },
+            templates: {
+                tag: coaTagTemplate,
+                dropdownItem: coaSuggestionItemTemplate
+            },
+            whitelist: coa_whitelist,
+        });
+    
+        tagify.on('dropdown:show dropdown:updated', onDefaultsDropdownShow);
+        tagify.on('dropdown:select', onDefaultsSelectSuggestion);
+        tagify.on('input', onDefaultsInput);
+        tagify.on('remove', onDefaultsRemove);
+    
+        tagify_defaults.push(tagify);
+    
+    });
+})
+
+function onDefaultsDropdownShow(e) {
+    var tagify = e.detail.tagify;
+}
+
+function onDefaultsSelectSuggestion(e) {
+    var tagify = e.detail.tagify;
+}
+
+function onDefaultsInput(e) {
+    var tagify = e.detail.tagify;
+    var value = e.detail.value;
+    
+    tagify.whitelist = null // reset the whitelist
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort
+    controller && controller.abort()
+    controller = new AbortController()
+
+    // show loading animation and hide the suggestions dropdown
+    tagify.loading(true).dropdown.hide()
+
+    fetch(`/ajax/settings/coa/search/${value}`, {signal:controller.signal})
+        .then(RES => RES.json())
+        .then(function(newWhitelist){
+            tagify.whitelist = newWhitelist // update whitelist Array in-place
+            tagify.loading(false).dropdown.show(value) // render the suggestions dropdown
+        })
+}
+
+function onDefaultsRemove(e) {
+    var tagify = e.detail.tagify;
+}
+
+function coaTagTemplate(tagData)
+{
+    return `
+        <tag title="${tagData.account_name}"
+                contenteditable='false'
+                spellcheck='false'
+                tabIndex="-1"
+                class="tagify__tag ${tagData.class ? tagData.class : ""}"
+                ${this.getAttributes(tagData)}>
+            <x title='' class='tagify__tag__removeBtn' role='button' aria-label='remove tag'></x>
+            <div>
+                <div class='tagify__tag__avatar-wrap'>
+                    <img onerror="this.style.visibility='hidden'" src="${tagData.avatar}">
+                </div>
+                <span class='tagify__tag-text'>${tagData.label}</span>
+            </div>
+        </tag>
+    `
+}
+
+function coaSuggestionItemTemplate(tagData)
+{
+    return `
+    <div ${this.getAttributes(tagData)}
+        class='tagify__dropdown__item ${tagData.class ? tagData.class : ""}'
+        tabindex="0"
+        role="option">
+        ${ tagData.avatar ? `
+        <div class='tagify__dropdown__item__avatar-wrap'>
+            <img onerror="this.style.visibility='hidden'" src="${tagData.avatar}">
+        </div>` : ''
+        }
+        <strong>${tagData.account_name}</strong><br>
+        <span>${tagData.chart_of_account_no} | ${tagData.category} | ${tagData.type}</span>
+    </div>
+`
+}

--- a/public/js/settings/defaults/defaults.js
+++ b/public/js/settings/defaults/defaults.js
@@ -2,53 +2,77 @@ var controller;
 
 var tagify_defaults_elms = document.querySelectorAll('.tagify-defaults');
 var tagify_defaults = [];
+var defaults_data;
 
 var coa_whitelist = [];
-var request = $.ajax({
-    url: '/ajax/settings/coa/search/',
+
+var request_defaults = $.ajax({
+    url: '/ajax/settings/defaults',
     type: 'GET',
-    dataType: 'json'
+    dataType: 'json',
 });
 
-request.done(function(data) {
+request_defaults.done(function(data) {
     console.log(data);
-    coa_whitelist = data;
+    defaults_data = data;
 });
 
-request.fail(function(jqXHR, textStatus) {
+request_defaults.fail(function(jqXHR, textStatus) {
     console.log('Request failed: ' + textStatus);
 });
 
-request.always(function() {
-    tagify_defaults_elms.forEach(function(elm){
-
-        var tagify = new Tagify(elm, {
-            tagTextProp: 'label', // very important since a custom template is used with this property as text
-            enforceWhitelist: true,
-            mode : "select",
-            skipInvalid: false, // do not remporarily add invalid tags
-            dropdown: {
-                closeOnSelect: true,
-                enabled: 0,
-                classname: 'customers-list',
-                searchKeys: ['label']  // very important to set by which keys to search for suggesttions when typing
-            },
-            templates: {
-                tag: coaTagTemplate,
-                dropdownItem: coaSuggestionItemTemplate
-            },
-            whitelist: coa_whitelist,
-        });
-    
-        tagify.on('dropdown:show dropdown:updated', onDefaultsDropdownShow);
-        tagify.on('dropdown:select', onDefaultsSelectSuggestion);
-        tagify.on('input', onDefaultsInput);
-        tagify.on('remove', onDefaultsRemove);
-    
-        tagify_defaults.push(tagify);
-    
+request_defaults.always(function() {
+    var request = $.ajax({
+        url: '/ajax/settings/coa/search/',
+        type: 'GET',
+        dataType: 'json'
     });
-})
+    
+    request.done(function(data) {
+        console.log(data);
+        coa_whitelist = data;
+    });
+    
+    request.fail(function(jqXHR, textStatus) {
+        console.log('Request failed: ' + textStatus);
+    });
+    
+    request.always(function() {
+        tagify_defaults_elms.forEach(function(elm){
+            console.log(elm.name);
+            if(defaults_data[elm.name] != undefined) {
+                var tagify_defaults = defaults_data[elm.name];
+                elm.value = `${tagify_defaults.chart_of_account_no} - ${tagify_defaults.account_name}`;
+            }
+    
+            var tagify = new Tagify(elm, {
+                tagTextProp: 'label', // very important since a custom template is used with this property as text
+                enforceWhitelist: true,
+                mode : "select",
+                skipInvalid: false, // do not remporarily add invalid tags
+                dropdown: {
+                    closeOnSelect: true,
+                    enabled: 0,
+                    classname: 'customers-list',
+                    searchKeys: ['label']  // very important to set by which keys to search for suggesttions when typing
+                },
+                templates: {
+                    tag: coaTagTemplate,
+                    dropdownItem: coaSuggestionItemTemplate
+                },
+                whitelist: coa_whitelist,
+            });
+        
+            tagify.on('dropdown:show dropdown:updated', onDefaultsDropdownShow);
+            tagify.on('dropdown:select', onDefaultsSelectSuggestion);
+            tagify.on('input', onDefaultsInput);
+            tagify.on('remove', onDefaultsRemove);
+        
+            window['tagify_defaults'].push(tagify);
+        
+        });
+    });
+});
 
 function onDefaultsDropdownShow(e) {
     var tagify = e.detail.tagify;

--- a/resources/views/settings/defaults/index.blade.php
+++ b/resources/views/settings/defaults/index.blade.php
@@ -43,14 +43,16 @@
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
                                 <button type="submit" class="btn btn-primary btn-sm">Save</button>
-                                <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
+                                <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
                     </form>    --}}
-                    <form class="my-3">
+                    <form class="my-3 ajax-submit-updated" method="post" action="{{ url('/ajax/settings/defaults/receipts') }}" data-message="Changes saved.">
+                        @csrf
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="receipt_cash_on_hand">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>1010-Cash on Hand</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -60,7 +62,8 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">VAT Payable:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="receipt_vat_payable">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>2100 - VAT Payable</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -70,7 +73,8 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Sales:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="receipt_sales">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>4100 - Sales</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -80,7 +84,8 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Account Receivable:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="receipt_account_receivable">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>1110 - Account Receivable</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -90,7 +95,8 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Sales Discount:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="receipt_sales_discount">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>4102 - Sales Discount</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -100,17 +106,18 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Withholding:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="receipt_withholding">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>1400 - Prepaid Tax</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
                                     </select>
                                 </div>
                         </div>
-                    <div class="form-group">
-                            <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
+                        <div class="form-group">
+                            {{-- <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button> --}}
                             <button type="submit" class="btn btn-primary btn-sm">Save</button>
-                            <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
+                            <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                         <div>
                     </form>
                 </section>
@@ -129,14 +136,16 @@
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
                                 <button type="submit" class="btn btn-primary btn-sm">Save</button>
-                                <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
+                                <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
                     </form>    --}}
-                    <form class="my-3">
+                    <form class="my-3 ajax-submit-updated" method="post" action="{{ url('/ajax/settings/defaults/advance-receipts') }}" data-message="Changes saved.">
+                        @csrf
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="advance_receipt_cash_on_hand">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>1010-Cash on Hand</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -146,17 +155,18 @@
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Advance Payment:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="advance_receipt_advance_payment">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>2109-Other Current Liability</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
                                     </select>
                                 </div>
                         </div>
-                    <div class="form-group">
-                            <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
+                        <div class="form-group">
+                            {{-- <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button> --}}
                             <button type="submit" class="btn btn-primary btn-sm">Save</button>
-                            <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
+                            <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                         <div>
                     </form>
                 </section>
@@ -174,14 +184,16 @@
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
                                 <button type="submit" class="btn btn-primary btn-sm">Save</button>
-                                <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
+                                <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
                     </form>    --}}
-                    <form class="my-3">
+                    <form class="my-3 ajax-submit-updated" method="post" action="{{ url('/ajax/settings/defaults/credit-receipts') }}" data-message="Changes saved.">
+                        @csrf
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="credit_receipt_cash_on_hand">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>1010-Cash on Hand</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -191,17 +203,18 @@
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Account Receivable</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="credit_receipt_account_receivable">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>1110 - Account Receivable</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
                                     </select>
                                 </div>
                         </div>
-                    <div class="form-group">
-                            <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
+                        <div class="form-group">
+                            {{-- <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button> --}}
                             <button type="submit" class="btn btn-primary btn-sm">Save</button>
-                            <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
+                            <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                         <div>
                     </form>
                 </section>
@@ -219,14 +232,16 @@
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
                                 <button type="submit" class="btn btn-primary btn-sm">Save</button>
-                                <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
+                                <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
                     </form>    --}}
-                    <form class="my-3">
+                    <form class="my-3 ajax-submit-updated" method="post" action="{{ url('/ajax/settings/defaults/bills') }}" data-message="Changes saved.">
+                        @csrf
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="bill_cash_on_hand">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>1010-Cash on Hand</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -236,7 +251,8 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Items for Sale</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="bill_items_for_sale">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>5100 - Cost of Goods Sold</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -246,7 +262,8 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Freight Charge Expense:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="bill_freight_charge_expense">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>5110 - Freight Charge</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -256,7 +273,8 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">VAT Receivable:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="bill_vat_receivable">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>1204 - VAT Receivable</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -266,7 +284,8 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Account Payable:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="bill_account_payable">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>2000 - Account Payable</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -276,17 +295,18 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Withholding:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="bill_withholding">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>2105 - Withholding Tax Payable</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
                                     </select>
                                 </div>
                         </div>
-                    <div class="form-group">
-                            <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
+                        <div class="form-group">
+                            {{-- <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button> --}}
                             <button type="submit" class="btn btn-primary btn-sm">Save</button>
-                            <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
+                            <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                         <div>
                     </form>
                 </section>
@@ -304,14 +324,16 @@
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
                                 <button type="submit" class="btn btn-primary btn-sm">Save</button>
-                                <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
+                                <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
                     </form>    --}}
-                    <form class="my-3">
+                    <form class="my-3 ajax-submit-updated" method="post" action="{{ url('/ajax/settings/defaults/payments') }}" data-message="Changes saved.">
+                        @csrf
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="payment_cash_on_hand">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>1010-Cash on Hand</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -321,7 +343,8 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">VAT Receivable:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="payment_vat_receivable">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>2100 - VAT Receivable</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -331,7 +354,8 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Account Payable</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="payment_account_payable">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>4100 - Account Payable</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -341,7 +365,8 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Withholding</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="payment_withholding">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>1110 - Withholding Tax Payable</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -351,7 +376,8 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Salary Payable</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="payment_salary_payable">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>4102 - Salary Payable</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
@@ -361,17 +387,18 @@
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Commission Payment</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" >
+                                    <select class="form-control" name="payment_commission_payment">
+                                        <option value="" disabled selected hidden>Select Chart of Account</option>
                                         <option value="1" Selected>1400 - Commission Expense</option>
                                         <option value="2">Two</option>
                                         <option value="3">Three</option>
                                     </select>
                                 </div>
                         </div>
-                    <div class="form-group">
-                            <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
+                        <div class="form-group">
+                            {{-- <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button> --}}
                             <button type="submit" class="btn btn-primary btn-sm">Save</button>
-                            <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
+                            <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                         <div>
                     </form>
                 </section>

--- a/resources/views/settings/defaults/index.blade.php
+++ b/resources/views/settings/defaults/index.blade.php
@@ -157,7 +157,7 @@
                                 <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
                     </form>    --}}
-                    <form class="my-3 ajax-submit-updated" method="post" action="{{ url('/ajax/settings/defaults/receipts') }}" data-message="Changes saved.">
+                    <form id="form-defaults-receipts" class="my-3 ajax-submit-updated" data-noreload="1" method="post" action="{{ url('/ajax/settings/defaults/receipts') }}" data-message="Changes saved.">
                         @csrf
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
@@ -197,7 +197,7 @@
                         </div>
                         <div class="form-group">
                             {{-- <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button> --}}
-                            <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                            <button type="submit" class="btn btn-primary btn-sm" form="form-defaults-receipts">Save</button>
                             <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                         <div>
                     </form>
@@ -220,7 +220,7 @@
                                 <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
                     </form>    --}}
-                    <form class="my-3 ajax-submit-updated" method="post" action="{{ url('/ajax/settings/defaults/advance-receipts') }}" data-message="Changes saved.">
+                    <form id="form-defaults-advance-receipts" class="my-3 ajax-submit-updated" data-noreload="1" method="post" action="{{ url('/ajax/settings/defaults/advance-receipts') }}" data-message="Changes saved.">
                         @csrf
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
@@ -236,7 +236,7 @@
                         </div>
                         <div class="form-group">
                             {{-- <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button> --}}
-                            <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                            <button type="submit" class="btn btn-primary btn-sm" form="form-defaults-advance-receipts">Save</button>
                             <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                         <div>
                     </form>
@@ -258,7 +258,7 @@
                                 <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
                     </form>    --}}
-                    <form class="my-3 ajax-submit-updated" method="post" action="{{ url('/ajax/settings/defaults/credit-receipts') }}" data-message="Changes saved.">
+                    <form id="form-defaults-credit-receipts" class="my-3 ajax-submit-updated" data-noreload="1" method="post" action="{{ url('/ajax/settings/defaults/credit-receipts') }}" data-message="Changes saved.">
                         @csrf
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
@@ -274,7 +274,7 @@
                         </div>
                         <div class="form-group">
                             {{-- <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button> --}}
-                            <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                            <button type="submit" class="btn btn-primary btn-sm" form="form-defaults-credit-receipts">Save</button>
                             <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                         <div>
                     </form>
@@ -296,7 +296,7 @@
                                 <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
                     </form>    --}}
-                    <form class="my-3 ajax-submit-updated" method="post" action="{{ url('/ajax/settings/defaults/bills') }}" data-message="Changes saved.">
+                    <form id="form-defaults-bills" class="my-3 ajax-submit-updated" data-noreload="1" method="post" action="{{ url('/ajax/settings/defaults/bills') }}" data-message="Changes saved.">
                         @csrf
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
@@ -336,7 +336,7 @@
                         </div>
                         <div class="form-group">
                             {{-- <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button> --}}
-                            <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                            <button type="submit" class="btn btn-primary btn-sm" form="form-defaults-bills">Save</button>
                             <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                         <div>
                     </form>
@@ -358,7 +358,7 @@
                                 <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
                     </form>    --}}
-                    <form class="my-3 ajax-submit-updated" method="post" action="{{ url('/ajax/settings/defaults/payments') }}" data-message="Changes saved.">
+                    <form id="form-defaults-payments" class="my-3 ajax-submit-updated" data-noreload="1" method="post" action="{{ url('/ajax/settings/defaults/payments') }}" data-message="Changes saved.">
                         @csrf
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
@@ -398,7 +398,7 @@
                         </div>
                         <div class="form-group">
                             {{-- <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button> --}}
-                            <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                            <button type="submit" class="btn btn-primary btn-sm" form="form-defaults-payments">Save</button>
                             <button type="button" class="btn btn-danger btn-sm">Cancel</button>
                         <div>
                     </form>

--- a/resources/views/settings/defaults/index.blade.php
+++ b/resources/views/settings/defaults/index.blade.php
@@ -33,7 +33,7 @@
             <!--Receipt content--->
             <div class="tab-pane fade show active receipt">                
                 <section>
-                    <form>
+                    {{-- <form>
                         <div class="input-group mb-3">
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">Fs#-</span>
@@ -45,7 +45,7 @@
                                 <button type="submit" class="btn btn-primary btn-sm">Save</button>
                                 <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
-                    </form>   
+                    </form>    --}}
                     <form class="my-3">
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
@@ -119,7 +119,7 @@
             <!--Advance Receipt content--->
             <div class=" tab-pane fade advance_receipt">
                 <section>
-                    <form>
+                    {{-- <form>
                         <div class="input-group mb-3">
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">AdvRec#-</span>
@@ -131,7 +131,7 @@
                                 <button type="submit" class="btn btn-primary btn-sm">Save</button>
                                 <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
-                    </form>   
+                    </form>    --}}
                     <form class="my-3">
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
@@ -164,7 +164,7 @@
             <!--Credit Receipt content--->
             <div class=" tab-pane fade credit_receipt">
                 <section>
-                    <form>
+                    {{-- <form>
                         <div class="input-group mb-3">
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">CrR#-</span>
@@ -176,7 +176,7 @@
                                 <button type="submit" class="btn btn-primary btn-sm">Save</button>
                                 <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
-                    </form>   
+                    </form>    --}}
                     <form class="my-3">
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
@@ -209,7 +209,7 @@
             <!--bill content--->
             <div class=" tab-pane fade bill">
             <section>
-                    <form>
+                    {{-- <form>
                         <div class="input-group mb-3">
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">Bill#-</span>
@@ -221,7 +221,7 @@
                                 <button type="submit" class="btn btn-primary btn-sm">Save</button>
                                 <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
-                    </form>   
+                    </form>    --}}
                     <form class="my-3">
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
@@ -294,7 +294,7 @@
              <!--payment content--->
             <div class=" tab-pane fade payment">
             <section>
-                    <form>
+                    {{-- <form>
                         <div class="input-group mb-3">
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">PV#-</span>
@@ -306,7 +306,7 @@
                                 <button type="submit" class="btn btn-primary btn-sm">Save</button>
                                 <button type="submit" class="btn btn-danger btn-sm">Cancel</button>
                             <div>
-                    </form>   
+                    </form>    --}}
                     <form class="my-3">
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>

--- a/resources/views/settings/defaults/index.blade.php
+++ b/resources/views/settings/defaults/index.blade.php
@@ -149,7 +149,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">Fs#-</span>
                             </div>
-                            <input type="text" class="form-control tagify-defaults" placeholder="Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
+                            <input disabled type="text" class="form-control tagify-defaults" placeholder="Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
                         </div>
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
@@ -162,37 +162,37 @@
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="receipt_cash_on_hand">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="receipt_cash_on_hand">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">VAT Payable:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="receipt_vat_payable">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="receipt_vat_payable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Sales:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="receipt_sales">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="receipt_sales">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Account Receivable:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="receipt_account_receivable">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="receipt_account_receivable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Sales Discount:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="receipt_sales_discount">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="receipt_sales_discount">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Withholding:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="receipt_withholding">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="receipt_withholding">
                                 </div>
                         </div>
                         <div class="form-group">
@@ -212,7 +212,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">AdvRec#-</span>
                             </div>
-                            <input type="text" class="form-control tagify-defaults" placeholder="Advance Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
+                            <input disabled type="text" class="form-control tagify-defaults" placeholder="Advance Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
                         </div>
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
@@ -225,13 +225,13 @@
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="advance_receipt_cash_on_hand">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="advance_receipt_cash_on_hand">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Advance Payment:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="advance_receipt_advance_payment">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="advance_receipt_advance_payment">
                                 </div>
                         </div>
                         <div class="form-group">
@@ -250,7 +250,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">CrR#-</span>
                             </div>
-                            <input type="text" class="form-control tagify-defaults" placeholder="Credit Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
+                            <input disabled type="text" class="form-control tagify-defaults" placeholder="Credit Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
                         </div>
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
@@ -263,13 +263,13 @@
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="credit_receipt_cash_on_hand">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="credit_receipt_cash_on_hand">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Account Receivable</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="credit_receipt_account_receivable">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="credit_receipt_account_receivable">
                                 </div>
                         </div>
                         <div class="form-group">
@@ -288,7 +288,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">Bill#-</span>
                             </div>
-                            <input type="text" class="form-control tagify-defaults" placeholder="Bill Reference Number" aria-label="Username" aria-describedby="basic-addon1">
+                            <input disabled type="text" class="form-control tagify-defaults" placeholder="Bill Reference Number" aria-label="Username" aria-describedby="basic-addon1">
                         </div>
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
@@ -301,37 +301,37 @@
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="bill_cash_on_hand">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="bill_cash_on_hand">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Items for Sale</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="bill_items_for_sale">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="bill_items_for_sale">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Freight Charge Expense:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="bill_freight_charge_expense">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="bill_freight_charge_expense">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">VAT Receivable:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="bill_vat_receivable">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="bill_vat_receivable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Account Payable:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="bill_account_payable">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="bill_account_payable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Withholding:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="bill_withholding">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="bill_withholding">
                                 </div>
                         </div>
                         <div class="form-group">
@@ -350,7 +350,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">PV#-</span>
                             </div>
-                            <input type="text" class="form-control tagify-defaults" placeholder="Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
+                            <input disabled type="text" class="form-control tagify-defaults" placeholder="Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
                         </div>
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
@@ -363,37 +363,37 @@
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="payment_cash_on_hand">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="payment_cash_on_hand">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">VAT Receivable:</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="payment_vat_receivable">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="payment_vat_receivable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Account Payable</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="payment_account_payable">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="payment_account_payable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Withholding</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="payment_withholding">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="payment_withholding">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Salary Payable</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="payment_salary_payable">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="payment_salary_payable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Commission Payment</label>
                                 <div class="col-md-10">
-                                    <input type="text" class="form-control tagify-defaults" name="payment_commission_payment">
+                                    <input disabled type="text" class="form-control tagify-defaults" name="payment_commission_payment">
                                 </div>
                         </div>
                         <div class="form-group">

--- a/resources/views/settings/defaults/index.blade.php
+++ b/resources/views/settings/defaults/index.blade.php
@@ -1,5 +1,116 @@
 @extends('template.index')
 
+@push('styles')
+<style>
+    .table-item-content {
+        /** Equivalent to pt-3 */
+        padding-top: 1rem !important;
+    }
+
+    .thead-actions {
+        /** Fixed width, increase if adding addt. buttons **/
+        width: 120px;
+    }
+
+    .content-card {
+        border-radius: 0px 0px 5px 5px;
+    }
+
+    .inputPrice::-webkit-inner-spin-button,
+    .inputTax::-webkit-inner-spin-button,
+    .inputPrice::-webkit-outer-spin-button,
+    .inputTax::-webkit-outer-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
+
+    input[type="checkbox"],
+    label {
+        cursor: pointer;
+    }
+
+    /*
+            TEMPORARY
+        */
+    /* Suggestions items */
+    .tagify__dropdown.customers-list .tagify__dropdown__item {
+        padding: .5em .7em;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0 1em;
+        grid-template-areas: "avatar name"
+            "avatar email";
+    }
+
+    .tagify__dropdown.customers-list .tagify__dropdown__item:hover .tagify__dropdown__item__avatar-wrap {
+        transform: scale(1.2);
+    }
+
+    .tagify__dropdown.customers-list .tagify__dropdown__item__avatar-wrap {
+        grid-area: avatar;
+        width: 36px;
+        height: 36px;
+        border-radius: 50%;
+        overflow: hidden;
+        background: #EEE;
+        transition: .1s ease-out;
+    }
+
+    .tagify__dropdown.customers-list img {
+        width: 100%;
+        vertical-align: top;
+    }
+
+    .tagify__dropdown.customers-list strong {
+        grid-area: name;
+        width: 100%;
+        align-self: center;
+    }
+
+    .tagify__dropdown.customers-list span {
+        grid-area: email;
+        width: 100%;
+        font-size: .9em;
+        opacity: .6;
+    }
+
+    .tagify__dropdown.customers-list .addAll {
+        border-bottom: 1px solid #DDD;
+        gap: 0;
+    }
+
+
+    /* Tags items */
+    .tagify__tag {
+        white-space: nowrap;
+    }
+
+    .tagify__tag:hover .tagify__tag__avatar-wrap {
+        transform: scale(1.6) translateX(-10%);
+    }
+
+    .tagify__tag .tagify__tag__avatar-wrap {
+        width: 16px;
+        height: 16px;
+        white-space: normal;
+        border-radius: 50%;
+        background: silver;
+        margin-right: 5px;
+        transition: .12s ease-out;
+    }
+
+    .tagify__tag img {
+        width: 100%;
+        vertical-align: top;
+        pointer-events: none;
+    }
+</style>
+
+<script src="https://unpkg.com/@yaireo/tagify"></script>
+<script src="https://unpkg.com/@yaireo/tagify/dist/tagify.polyfills.min.js"></script>
+<link href="https://unpkg.com/@yaireo/tagify/dist/tagify.css" rel="stylesheet" type="text/css" />
+@endpush
+
 @section('content')
 
 <div>
@@ -38,7 +149,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">Fs#-</span>
                             </div>
-                            <input type="text" class="form-control" placeholder="Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
+                            <input type="text" class="form-control tagify-defaults" placeholder="Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
                         </div>
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
@@ -51,67 +162,37 @@
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="receipt_cash_on_hand">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>1010-Cash on Hand</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="receipt_cash_on_hand">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">VAT Payable:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="receipt_vat_payable">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>2100 - VAT Payable</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="receipt_vat_payable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Sales:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="receipt_sales">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>4100 - Sales</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="receipt_sales">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Account Receivable:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="receipt_account_receivable">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>1110 - Account Receivable</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="receipt_account_receivable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Sales Discount:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="receipt_sales_discount">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>4102 - Sales Discount</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="receipt_sales_discount">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Withholding:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="receipt_withholding">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>1400 - Prepaid Tax</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="receipt_withholding">
                                 </div>
                         </div>
                         <div class="form-group">
@@ -131,7 +212,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">AdvRec#-</span>
                             </div>
-                            <input type="text" class="form-control" placeholder="Advance Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
+                            <input type="text" class="form-control tagify-defaults" placeholder="Advance Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
                         </div>
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
@@ -144,23 +225,13 @@
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="advance_receipt_cash_on_hand">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>1010-Cash on Hand</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="advance_receipt_cash_on_hand">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Advance Payment:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="advance_receipt_advance_payment">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>2109-Other Current Liability</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="advance_receipt_advance_payment">
                                 </div>
                         </div>
                         <div class="form-group">
@@ -179,7 +250,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">CrR#-</span>
                             </div>
-                            <input type="text" class="form-control" placeholder="Credit Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
+                            <input type="text" class="form-control tagify-defaults" placeholder="Credit Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
                         </div>
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
@@ -192,23 +263,13 @@
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="credit_receipt_cash_on_hand">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>1010-Cash on Hand</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="credit_receipt_cash_on_hand">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Account Receivable</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="credit_receipt_account_receivable">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>1110 - Account Receivable</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="credit_receipt_account_receivable">
                                 </div>
                         </div>
                         <div class="form-group">
@@ -227,7 +288,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">Bill#-</span>
                             </div>
-                            <input type="text" class="form-control" placeholder="Bill Reference Number" aria-label="Username" aria-describedby="basic-addon1">
+                            <input type="text" class="form-control tagify-defaults" placeholder="Bill Reference Number" aria-label="Username" aria-describedby="basic-addon1">
                         </div>
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
@@ -240,67 +301,37 @@
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="bill_cash_on_hand">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>1010-Cash on Hand</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="bill_cash_on_hand">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Items for Sale</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="bill_items_for_sale">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>5100 - Cost of Goods Sold</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="bill_items_for_sale">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Freight Charge Expense:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="bill_freight_charge_expense">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>5110 - Freight Charge</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="bill_freight_charge_expense">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">VAT Receivable:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="bill_vat_receivable">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>1204 - VAT Receivable</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="bill_vat_receivable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Account Payable:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="bill_account_payable">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>2000 - Account Payable</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="bill_account_payable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Withholding:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="bill_withholding">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>2105 - Withholding Tax Payable</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="bill_withholding">
                                 </div>
                         </div>
                         <div class="form-group">
@@ -319,7 +350,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="basic-addon1">PV#-</span>
                             </div>
-                            <input type="text" class="form-control" placeholder="Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
+                            <input type="text" class="form-control tagify-defaults" placeholder="Receipt Reference Number" aria-label="Username" aria-describedby="basic-addon1">
                         </div>
                         <div class="form-group">
                                 <button type="submit" class="btn btn-secondary btn-sm">Set as Default</button>
@@ -332,67 +363,37 @@
                         <div class="form-group row">
                             <label class="col-md-2 col-form-label">Cash on Hand:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="payment_cash_on_hand">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>1010-Cash on Hand</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="payment_cash_on_hand">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">VAT Receivable:</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="payment_vat_receivable">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>2100 - VAT Receivable</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="payment_vat_receivable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Account Payable</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="payment_account_payable">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>4100 - Account Payable</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="payment_account_payable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Withholding</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="payment_withholding">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>1110 - Withholding Tax Payable</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="payment_withholding">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Salary Payable</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="payment_salary_payable">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>4102 - Salary Payable</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="payment_salary_payable">
                                 </div>
                         </div>
                         <div class="form-group row">
                             <label  class="col-md-2 col-form-label">Commission Payment</label>
                                 <div class="col-md-10">
-                                    <select class="form-control" name="payment_commission_payment">
-                                        <option value="" disabled selected hidden>Select Chart of Account</option>
-                                        <option value="1" Selected>1400 - Commission Expense</option>
-                                        <option value="2">Two</option>
-                                        <option value="3">Three</option>
-                                    </select>
+                                    <input type="text" class="form-control tagify-defaults" name="payment_commission_payment">
                                 </div>
                         </div>
                         <div class="form-group">
@@ -414,4 +415,5 @@
         $('.dataTables_filter').addClass('pull-right');
     });
 </script>
+<script src="{{ url('/js/settings/defaults/defaults.js') }}"></script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -600,6 +600,8 @@ Route::group([
                     'as' => 'ajax.',
                     'prefix' => 'ajax/settings/defaults',
                 ], function(){
+                    Route::get('/', [DefaultsController::class, 'getDefaults'])->name('getDefaults');
+
                     Route::post('/receipts', [DefaultsController::class, 'updateReceipts'])->name('updateReceipts');
                     Route::post('/advance-receipts', [DefaultsController::class, 'updateAdvanceReceipts'])->name('updateAdvanceReceipts');
                     Route::post('/credit-receipts', [DefaultsController::class, 'updateCreditReceipts'])->name('updateCreditReceipts');

--- a/routes/web.php
+++ b/routes/web.php
@@ -568,7 +568,7 @@ Route::group([
                 Route::post('/settings/coa', [ChartOfAccountsController::class, 'store'])->name('store');
                 
                 // AJAX
-                Route::get('/ajax/settings/coa/search/{query}', [ChartOfAccountsController::class, 'ajaxSearchCOA']);
+                Route::get('/ajax/settings/coa/search/{query?}', [ChartOfAccountsController::class, 'ajaxSearchCOA']);
                 Route::get('/ajax/settings/coa_categories/search', [ChartOfAccountsController::class, 'ajaxSearchCategories']);
                 Route::get('/ajax/settings/coa_categories/search/{query}', [ChartOfAccountsController::class, 'ajaxSearchCategories']);
                 Route::get('/ajax/settings/coa/beginning-balance', [ChartOfAccountsController::class, 'ajaxGetCOAForBeginningBalance']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,6 +59,8 @@ use App\Http\Controllers\Settings\CompanyInfoController;
 
 // Notifications
 use App\Http\Controllers\NotificationController;
+use App\Http\Controllers\Settings\DefaultsController;
+
 /*
 |--------------------------------------------------------------------------
 | Web Routes
@@ -591,7 +593,19 @@ Route::group([
                 'as' => 'defaults.'
             ], function(){
                 // HTTP
-                Route::view('/settings/defaults', 'settings.defaults.index')->name('index');
+                Route::get('/settings/defaults', [DefaultsController::class, 'index'])->name('index');
+
+                // AJAX
+                Route::group([
+                    'as' => 'ajax.',
+                    'prefix' => 'ajax/settings/defaults',
+                ], function(){
+                    Route::post('/receipts', [DefaultsController::class, 'updateReceipts'])->name('updateReceipts');
+                    Route::post('/advance-receipts', [DefaultsController::class, 'updateAdvanceReceipts'])->name('updateAdvanceReceipts');
+                    Route::post('/credit-receipts', [DefaultsController::class, 'updateCreditReceipts'])->name('updateCreditReceipts');
+                    Route::post('/bills', [DefaultsController::class, 'updateBills'])->name('updateBills');
+                    Route::post('/payments' ,[DefaultsController::class, 'updatePayments'])->name('updatePayments');
+                });
             });
         });
     });


### PR DESCRIPTION
Field involving reference ids won't be included in this PR. This will focus on fields involving chart of accounts.

TODO:
- [x] Update accounting system model and migrations to add fields from `Settings > Defaults`.
- [x] Temporarily hide reference id fields
- [x] Convert all COA-related fields into a Tagify field
- [x] Code COA search (or just reuse one and link to it)
- [x] Implement save
  - [x] Receipts
  - [x] Advance Receipts
  - [x] Credit Receipts
  - [x] Bills
  - [x] Payments
- [x] Load current values when accessing the site.

TODO Next:
Integration to Receipts for Receipts to have integration with COA.