### PR TITLE
Fix critical bug where creating COA with category ids more than 10 can't be created properly

### DIFF
--- a/app/Http/Controllers/Settings/ChartOfAccountsController.php
+++ b/app/Http/Controllers/Settings/ChartOfAccountsController.php
@@ -81,26 +81,24 @@ class ChartOfAccountsController extends Controller
     {
         $accounting_system_id = $this->request->session()->get('accounting_system_id');
         $coa_category = json_decode($request->coa_category, true);
-        
-        // To get the category_id of coa, use
-        // $coa[0]['value'];
-        // other related info such as type, category name,
-        // can be seen by changing `value` to its corresponding
-        // column name.
 
+        // Search category by value
+        $category = ChartOfAccountCategory::where('category', $coa_category[0]['value'])->first();
+        
         // Validation
         // TODO: Check if specific COA number already exists.
 
         // Create Chart of Account Entry
         $coa = new ChartOfAccounts();
         $coa->accounting_system_id = $accounting_system_id;
-        $coa->chart_of_account_category_id = $coa_category[0]['value'];
+        $coa->chart_of_account_category_id = $category['id'];
         $coa->chart_of_account_no = $request->coa_number;
         $coa->account_name = $request->account_name;
         $coa->current_balance = 0.00;
         $coa->save();
+        
         // If COA is Cash (id:1) and checkbox is checked.
-        if(isset($request->coa_is_bank) && $coa_category[0]['value'] == 1)
+        if(isset($request->coa_is_bank) && $category['id'] == 1)
         {
             $accounts = new BankAccounts();
             $accounts->chart_of_account_id = $coa->id;
@@ -109,8 +107,6 @@ class ChartOfAccountsController extends Controller
             $accounts->bank_account_type = $request->bank_account_type;
             $accounts->save();
         }
-
-        
        
         // Get Beginning Balance Journal Entry
         $je = JournalEntries::where('accounting_system_id', $accounting_system_id)
@@ -121,7 +117,7 @@ class ChartOfAccountsController extends Controller
             'accounting_system_id' => $accounting_system_id,
             'journal_entry_id' => $je->id,
             'chart_of_account_id' => $coa->id,
-            'type' => $coa_category[0]['normal_balance'] == 'Debit' ? 'debit' : 'credit',
+            'type' => $category['normal_balance'] == 'Debit' ? 'debit' : 'credit',
             'amount' => 0.00,
         ]);
 
@@ -273,10 +269,10 @@ class ChartOfAccountsController extends Controller
     public function ajaxSearchCategories($query = null)
     {
         $categories = ChartOfAccountCategory::select(
-            'id as value', 
-            'category',
-            'type',
-            'normal_balance');
+            'category as value'); 
+            // 'category',
+            // 'type',
+            // 'normal_balance');
             
         if(isset($query))
             $categories->where('category', 'LIKE', '%' . $query . '%');

--- a/public/js/settings/chart_of_accounts/select_coa_category.js
+++ b/public/js/settings/chart_of_accounts/select_coa_category.js
@@ -17,15 +17,15 @@ request.done(function(response, textStatus, jqXHR){
 
     // initialize tagify
     coa_select_category_tagify = new Tagify(coa_select_category_elm, {
-        tagTextProp: 'category', // very important since a custom template is used with this property as text
+        tagTextProp: 'value', // very important since a custom template is used with this property as text
         enforceWhitelist: true,
         mode : "select",
-        skipInvalid: false, // do not remporarily add invalid tags
+        skipInvalid: true, // do not remporarily add invalid tags
         dropdown: {
             closeOnSelect: true,
             enabled: 0,
-            classname: 'coa-list',
-            searchKeys: ['category', 'type', 'normal_balance']  // very important to set by which keys to search for suggesttions when typing
+            classname: 'customer-list',
+            searchKeys: ['value']  // very important to set by which keys to search for suggesttions when typing
         },
         templates: {
             tag: coaCategoryTagTemplate,
@@ -53,7 +53,7 @@ function onCOASelectCategorySelectSuggestion(e){
     console.log(e.detail.data);
 
     // If Cash, enable checkbox "Is this a Bank Account?"
-    if(e.detail.data.value == 1) 
+    if(e.detail.data.value == 'Cash') 
         $("#coa_is_bank").removeAttr("disabled");
     else {
         if($('#coa_is_bank').is(":checked"))

--- a/public/js/settings/chart_of_accounts/template_select_coa_category.js
+++ b/public/js/settings/chart_of_accounts/template_select_coa_category.js
@@ -1,6 +1,6 @@
 function coaCategoryTagTemplate(tagData){
     return `
-        <tag title="${tagData.category}"
+        <tag title="${tagData.value}"
                 contenteditable='false'
                 spellcheck='false'
                 tabIndex="-1"
@@ -11,7 +11,7 @@ function coaCategoryTagTemplate(tagData){
                 <div class='tagify__tag__avatar-wrap'>
                     <img onerror="this.style.visibility='hidden'" src="${tagData.avatar}">
                 </div>
-                <span class='tagify__tag-text'>${tagData.category}</span>
+                <span class='tagify__tag-text'>${tagData.value}</span>
             </div>
         </tag>
     `
@@ -28,8 +28,7 @@ function coaCategorySuggestionItemTemplate(tagData){
                 <img onerror="this.style.visibility='hidden'" src="${tagData.avatar}">
             </div>` : ''
             }
-            <strong>${tagData.category}</strong><br>
-            <span>${tagData.type}</span>
+            <strong>${tagData.value}</strong><br>
         </div>
     `
 }


### PR DESCRIPTION
An issue with coa category where selecting an id more than 10 won't include id when form is submitted. It only shows `value` as current name and `category as current name instead of the usual `value`=id, `category`=category, etc.