### PR TITLE
Rework Subscription User Invitation

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -35,6 +35,7 @@ class HomeController extends Controller
             ->where('subscription_users.user_id', Auth::id())
             ->rightJoin('accounting_system_users', 'subscription_users.id', '=', 'accounting_system_users.subscription_user_id')
             ->leftJoin('accounting_systems', 'accounting_system_users.accounting_system_id', '=', 'accounting_systems.id')
+            ->where('subscription_users.is_accepted', true)
             ->get();
 
         $this->request->session()->put('acct_system_count', count($acct_systems));

--- a/app/Http/Controllers/Subscription/ManageAccountingSystemsController.php
+++ b/app/Http/Controllers/Subscription/ManageAccountingSystemsController.php
@@ -20,6 +20,7 @@ class ManageAccountingSystemsController extends Controller
         $subscription_access = SubscriptionUser::where('user_id', auth()->id())
             ->where('subscription_users.role', '!=', 'member')
             ->where('subscription_users.role', '!=', 'moderator')
+            ->where('subscription_users.is_accepted', true)
             ->get();
         // return $subscription_access;
 

--- a/app/Http/Controllers/Subscription/ManageSubscriptionUsersController.php
+++ b/app/Http/Controllers/Subscription/ManageSubscriptionUsersController.php
@@ -88,7 +88,7 @@ class ManageSubscriptionUsersController extends Controller
             'password' => bcrypt($password),
         ]);
 
-        $subscription_user = SubscriptionUser::firstOrCreate([
+        $subscription_user = SubscriptionUser::updateOrCreate([
             'subscription_id' => $request->subscription_id,
             'user_id' => $user->id,
         ], [

--- a/app/Http/Middleware/HasSubscriptionMiddleware.php
+++ b/app/Http/Middleware/HasSubscriptionMiddleware.php
@@ -19,7 +19,6 @@ class HasSubscriptionMiddleware
         $subscription_admin_count = \App\Models\SubscriptionUser::where('user_id', auth()->id())
             ->where('subscription_users.role', '!=', 'member')
             ->where('subscription_users.role', '!=', 'moderator')
-            ->where('subscription_users.is_accepted', true)
             ->count();
 
         if($subscription_admin_count == 0) {

--- a/app/Http/Middleware/HasSubscriptionMiddleware.php
+++ b/app/Http/Middleware/HasSubscriptionMiddleware.php
@@ -16,7 +16,11 @@ class HasSubscriptionMiddleware
      */
     public function handle(Request $request, Closure $next)
     {
-        $subscription_admin_count = \App\Models\SubscriptionUser::where('user_id', auth()->id())->count();
+        $subscription_admin_count = \App\Models\SubscriptionUser::where('user_id', auth()->id())
+            ->where('subscription_users.role', '!=', 'member')
+            ->where('subscription_users.role', '!=', 'moderator')
+            ->where('subscription_users.is_accepted', true)
+            ->count();
 
         if($subscription_admin_count == 0) {
             return abort(403);

--- a/app/Models/SubscriptionUser.php
+++ b/app/Models/SubscriptionUser.php
@@ -13,6 +13,7 @@ class SubscriptionUser extends Model
         'subscription_id',
         'user_id',
         'role',
+        'is_accepted',
     ];
 
     public function subscription()

--- a/database/migrations/2022_02_04_013740_create_subscription_users_table.php
+++ b/database/migrations/2022_02_04_013740_create_subscription_users_table.php
@@ -23,6 +23,7 @@ class CreateSubscriptionUsersTable extends Migration
                 'moderator',    // manage users
                 'member',       // profile
             ]);
+            $table->boolean('is_accepted')->default(true);
             $table->timestamps();
         });
     }

--- a/resources/views/subscription/index.blade.php
+++ b/resources/views/subscription/index.blade.php
@@ -20,6 +20,8 @@
                 Subscription ID: {{ $subscription->id }}
                 @if(auth()->id() == $subscription->user_id)
                     <span class='badge badge-success'>Owned</span>
+                @elseif($subscription->is_accepted == 0)
+                    <span class='badge badge-warning'>Invited</span>
                 @endif
             </h5>
             <div class="table-responsive">
@@ -77,6 +79,14 @@
                         </td>
                     </tr>
                 </table>
+                @if($subscription->is_accepted == 0)
+                    You are invited to this subscription.
+                    <!-- Add button group with accept and reject buttons -->
+                    <div class="btn-group">
+                        <button type="button" data-id="{{ $subscription->subscription_user_id }}" class="btn btn-success btn-accept-invitation">Accept</button>
+                        <button type="button" data-id="{{ $subscription->subscription_user_id }}" class="btn btn-danger btn-reject-invitation">Reject</button>
+                    </div>
+                @endif
             </div>
         </div>
     </div>
@@ -84,3 +94,51 @@
 </div>
 
 @endsection
+
+@push('scripts')
+<script>
+    $(document).on('click', '.btn-accept-invitation', function() {
+        var id = $(this).data('id');
+        $.ajax({
+            url: '/ajax/subscription/accept-invitation',
+            type: 'POST',
+            data: {
+                id: id,
+                _token: '{{ csrf_token() }}',
+                _method: 'PATCH'
+            },
+            success: function(response) {
+                console.log(response);
+                if(response.success) {
+                    location.reload();
+                }
+            }, 
+            error: function(response) {
+                console.log(response);
+            }
+        });
+    });
+
+    $(document).on('click', '.btn-reject-invitation', function() {
+        var id = $(this).data('id');
+        $.ajax({
+            url: '/ajax/subscription/reject-invitation',
+            type: 'POST',
+            data: {
+                id: id,
+                _token: '{{ csrf_token() }}',
+                _method: 'DELETE'
+            },
+            success: function(response) {
+                console.log(response);
+                if(response.success) {
+                    location.reload();
+                }
+            },
+            error: function(response) {
+                console.log(response);
+            }
+        });
+    });
+</script>
+@endpush

--- a/resources/views/subscription/users/index.blade.php
+++ b/resources/views/subscription/users/index.blade.php
@@ -13,7 +13,8 @@
     <div class="card-body">
         <div class="btn-group mb-3" role="group" aria-label="Button group with nested dropdown">
             <div class="btn-group" role="group">
-                <button id="btnGroupDrop1" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown"
+                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#modal-add-new-user">Invite User</button>
+                {{-- <button id="btnGroupDrop1" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown"
                 aria-haspopup="true" aria-expanded="false">
                     <span class="icon text-white-50">
                         <i class="fas fa-user"></i>
@@ -23,7 +24,7 @@
                 <div class="dropdown-menu" aria-labelledby="btnGroupDrop1">
                     <a role="button" class="dropdown-item" data-toggle="modal" data-target="#modal-add-new-user">New User</a>
                     <a role="button" class="dropdown-item" data-toggle="modal" data-target="#modal-add-existing-user">Existing User</a>
-                </div>
+                </div> --}}
             </div>
         </div>
 

--- a/resources/views/subscription/users/index.blade.php
+++ b/resources/views/subscription/users/index.blade.php
@@ -67,7 +67,12 @@
                             <tbody>
                                 @foreach($output['users'] as $subscriptionUser)
                                     <tr>
-                                        <td>{{ $subscriptionUser->user->firstName . ' ' . $subscriptionUser->user->lastName }}</td>
+                                        <td>
+                                            {{ $subscriptionUser->user->firstName . ' ' . $subscriptionUser->user->lastName }}
+                                            @if(!$subscriptionUser->is_accepted)
+                                                <span class="badge badge-warning">Invited</span>
+                                            @endif
+                                        </td>
                                         <td>{{ $subscriptionUser->user->email }}</td>
                                         <td>
                                             @if($subscriptionUser->role == 'super admin')
@@ -106,12 +111,12 @@
 </div>
 
 {{-- Modals --}}
-{{-- P1: Add New User --}}
+{{-- P1: Formerly Add New User, Now Invite User --}}
 <div class="modal fade" id="modal-add-new-user" tabindex="-1" role="dialog" aria-labelledby="modal-add-new-user-label" aria-hidden="true">
     <div class="modal-dialog modal-md" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="modal-add-new-user-label">Add New User to Subscription</h5>
+                <h5 class="modal-title" id="modal-add-new-user-label">Invite User</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -123,7 +128,7 @@
                 <form id="form-add-new-user" method="post" action="{{ url('/ajax/subscription/user/add/new')}}">
                     @csrf
                     <div class="form-group row">
-                        <label for="anu_subscription_id" class="col-12 col-lg-6 col-form-label">Subscription<span class="text-danger ml-1">*</span></label>
+                        <label for="anu_subscription_id" class="col-12 col-lg-6 col-form-label">Select Subscription<span class="text-danger ml-1">*</span></label>
                         <div class="col-12 col-lg-6">
                             <select class="form-control form-control-select select-subscription" id="anu_subscription_id" name="subscription_id" required>
                                 @foreach($result as $output)
@@ -132,22 +137,23 @@
                             </select>
                         </div>
                     </div>
-                    <div class="form-group row">
+                    {{-- <div class="form-group row">
                         <label for="anu_first_name" class="col-12 col-lg-6 col-form-label">First Name<span class="text-danger ml-1">*</span></label>
                         <div class="col-12 col-lg-6">
                             <input type="text" class="form-control" id="anu_first_name" name="first_name" required>
                         </div>
-                    </div>
-                    <div class="form-group row">
+                    </div> --}}
+                    {{-- <div class="form-group row">
                         <label for="anu_last_name" class="col-12 col-lg-6 col-form-label">Last Name<span class="text-danger ml-1">*</span></label>
                         <div class="col-12 col-lg-6">
                             <input type="text" class="form-control" id="anu_last_name" name="last_name" required>
                         </div>
-                    </div>
+                    </div> --}}
                     <div class="form-group row">
                         <label for="anu_email" class="col-12 col-lg-6 col-form-label">Email<span class="text-danger ml-1">*</span></label>
                         <div class="col-12 col-lg-6">
                             <input type="email" class="form-control" id="anu_email" name="email" required>
+                            <p class="text-danger error-message error-message-email" style="display:none"></p>
                         </div>
                     </div>
                     <div class="form-group row">
@@ -165,7 +171,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                <button type="submit" class="btn btn-primary" id="anu_submit_btn" form="form-add-new-user">Create & Invite User</button>
+                <button type="submit" class="btn btn-primary" id="anu_submit_btn" form="form-add-new-user">Invite User</button>
             </div>
         </div>
     </div>
@@ -434,6 +440,7 @@
             e.preventDefault();
 
             form = $(this);
+            $('#modal-add-new-user .error-message').hide();
 
             $('#form-add-new-user button[type="submit"]').prop('disabled', true);
 
@@ -449,6 +456,11 @@
 
             request.done(function(res){
                 console.log(res);
+
+                if(res.success == false) {
+                    $('#modal-add-new-user .error-message').text(res.message).show();
+                    return;
+                }
 
                 $('#modal-add-new-user').modal('hide');
                 $('#modal-add-access-user').modal('show');

--- a/resources/views/template/navbar.blade.php
+++ b/resources/views/template/navbar.blade.php
@@ -13,7 +13,11 @@
     $unreadNotifications = Notification::where('accounting_system_id', session('accounting_system_id'))
         ->where('resolved', 0)->count();
     $accounting_periods = \App\Models\Settings\ChartOfAccounts\AccountingPeriods::where('accounting_system_id', session('accounting_system_id'))->get();
-    $subscription_admin_count = \App\Models\SubscriptionUser::where('user_id', auth()->id())->count();
+    $subscription_admin_count = \App\Models\SubscriptionUser::where('user_id', auth()->id())
+        ->where('subscription_users.role', '!=', 'member')
+        ->where('subscription_users.role', '!=', 'moderator')
+        ->where('subscription_users.is_accepted', true)
+        ->count();
 @endphp
  
  <!-- Sidebar -->

--- a/resources/views/template/navbar.blade.php
+++ b/resources/views/template/navbar.blade.php
@@ -16,7 +16,6 @@
     $subscription_admin_count = \App\Models\SubscriptionUser::where('user_id', auth()->id())
         ->where('subscription_users.role', '!=', 'member')
         ->where('subscription_users.role', '!=', 'moderator')
-        ->where('subscription_users.is_accepted', true)
         ->count();
 @endphp
  

--- a/routes/web.php
+++ b/routes/web.php
@@ -164,8 +164,9 @@ Route::group([
                 Route::get('/get/accounting-systems/{subscription}', [ManageSubscriptionUsersController::class, 'ajaxGetAccountingSystems']);
 
                 // Part 1: When adding new user.
-                Route::post('/add/new', [ManageSubscriptionUsersController::class, 'ajaxAddNewUser']); 
-                Route::post('/add/existing', [ManageSubscriptionUsersController::class, 'ajaxAddExistingUser']);
+                Route::post('/add/new', [ManageSubscriptionUsersController::class, 'ajaxInviteUser']); 
+                // Route::post('/add/new', [ManageSubscriptionUsersController::class, 'ajaxAddNewUser']); 
+                // Route::post('/add/existing', [ManageSubscriptionUsersController::class, 'ajaxAddExistingUser']);
 
                 // Part 2: Adding access after adding new user.
                 Route::post('/add/access/{subscriptionUser}', [ManageSubscriptionUsersController::class, 'ajaxAddAccess']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -152,6 +152,10 @@ Route::group([
 
             Route::get('/subscription/users', [ManageSubscriptionUsersController::class, 'index']);
 
+            // Invitation Accept/Reject
+            Route::patch('/ajax/subscription/accept-invitation', [SummaryController::class, 'ajaxAcceptInvitation']);
+            Route::delete('/ajax/subscription/reject-invitation', [SummaryController::class, 'ajaxRejectInvitation']);
+
 
             // AJAX
             Route::group([


### PR DESCRIPTION
Subscription Users will be invited through `firstOrCreate()` query builder function. If the email does not exist, a new account will be created which will be used as reference to add a `SubscriptionUser` model. Otherwise, use the existing account.

To make this work smoothly, I added a new `is_accepted` attribute to `SubscriptionUser`. Invited users won't have direct access to the subscription and the accounting systems they are assigned until they accept the invitation.