### PR TITLE
Implement Aged Receivables' Report

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -84,8 +84,6 @@ class ReportsController extends Controller
                 ->orderBy('customers.name', 'asc')
                 ->get();
 
-            // return $results;
-
             $pdf = \PDF::loadView('reports.customers.pdf.aged_receivable.summary', compact('request'), compact('results'));
         }
         else if($request->type == 'detailed') {

--- a/resources/views/reports/customers/index.blade.php
+++ b/resources/views/reports/customers/index.blade.php
@@ -37,7 +37,7 @@
                             <div class="form-group">
                                 <label for="date_from">Date From</label>
                                 <input type="date" class="form-control" id="date_from" name="date_from"
-                                    value="{{ date('Y-m-d') }}" required>
+                                    value="{{ now()->subDays(30)->format('Y-m-d') }}" required>
                             </div>
                         </div>
                     </div>

--- a/resources/views/reports/customers/index.blade.php
+++ b/resources/views/reports/customers/index.blade.php
@@ -30,7 +30,7 @@
             <!--Bill Payment content--->
             <div class="tab-pane fade show active aged_receivable">
 
-                <form action="{{route('reports.aged_receivable.pdf')}}" method="POST">
+                <form action="{{route('reports.aged_receivable.pdf')}}" method="POST" target="_blank">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">
@@ -47,6 +47,18 @@
                                 <label for="date_to">Date To</label>
                                 <input type="date" class="form-control" id="date_to" name="date_to"
                                     value="{{ date('Y-m-d') }}">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-xl-6">
+                            <div class="form-group">
+                                <label for="type">Type</label>
+                                <select class="form-control form-control-select" id="type" name="type">
+                                    <option value="" hidden selected>Select Report Type ...</option>
+                                    <option value="summary">Summary</option>
+                                    <option value="detailed">Detailed</option>
+                                </select>
                             </div>
                         </div>
                     </div>

--- a/resources/views/reports/customers/index.blade.php
+++ b/resources/views/reports/customers/index.blade.php
@@ -37,7 +37,7 @@
                             <div class="form-group">
                                 <label for="date_from">Date From</label>
                                 <input type="date" class="form-control" id="date_from" name="date_from"
-                                    value="{{ date('Y-m-d') }}">
+                                    value="{{ date('Y-m-d') }}" required>
                             </div>
                         </div>
                     </div>
@@ -46,7 +46,7 @@
                             <div class="form-group">
                                 <label for="date_to">Date To</label>
                                 <input type="date" class="form-control" id="date_to" name="date_to"
-                                    value="{{ date('Y-m-d') }}">
+                                    value="{{ date('Y-m-d') }}" required>
                             </div>
                         </div>
                     </div>
@@ -54,7 +54,7 @@
                         <div class="col-xl-6">
                             <div class="form-group">
                                 <label for="type">Type</label>
-                                <select class="form-control form-control-select" id="type" name="type">
+                                <select class="form-control form-control-select" id="type" name="type" required>
                                     <option value="" hidden selected>Select Report Type ...</option>
                                     <option value="summary">Summary</option>
                                     <option value="detailed">Detailed</option>

--- a/resources/views/reports/customers/pdf/aged_receivable.blade.php
+++ b/resources/views/reports/customers/pdf/aged_receivable.blade.php
@@ -1,6 +1,0 @@
-
-@extends('reports.template')
-@section('page_title', 'Aged Receivables')
-@section('content')
-
-@endsection

--- a/resources/views/reports/customers/pdf/aged_receivable/detailed.blade.php
+++ b/resources/views/reports/customers/pdf/aged_receivable/detailed.blade.php
@@ -5,11 +5,16 @@
 
 @php
     $customer_id = 0;
+    $total_grand = 0;
 @endphp
 
 @foreach($results as $result)
 
     @if($customer_id != $result->customer_id && $customer_id != 0)
+        @php
+            $total_sub = $total_current + $total_thirty_days + $total_sixty_days + $total_ninety_days + $total_over_ninety_days;
+            $total_grand += $total_sub;
+        @endphp
             </tbody>
             <tfoot>
                 <th class="text-start" colspan="3">Total</th>
@@ -18,6 +23,10 @@
                 <th class="text-end">{{ number_format($total_sixty_days, 2) }}</th>
                 <th class="text-end">{{ number_format($total_ninety_days, 2) }}</th>
                 <th class="text-end">{{ number_format($total_over_ninety_days, 2) }}</th>
+            </tfoot>
+            <tfoot>
+                <th class="text-start" colspan="7">Sub Total</th>
+                <th class="text-end" style="color:darkred"><strong>{{ number_format($total_sub, 2) }}</strong></th>
             </tfoot>
         </table>
     @endif
@@ -66,6 +75,10 @@
     @endphp
 
     @if($loop->last)
+        @php
+            $total_sub = $total_current + $total_thirty_days + $total_sixty_days + $total_ninety_days + $total_over_ninety_days;
+            $total_grand += $total_sub;
+        @endphp
         </tbody>
         <tfoot>
             <th class="text-start" colspan="3">Total</th>
@@ -75,9 +88,21 @@
             <th class="text-end">{{ number_format($total_ninety_days, 2) }}</th>
             <th class="text-end">{{ number_format($total_over_ninety_days, 2) }}</th>
         </tfoot>
+        <tfoot>
+            <th class="text-start" colspan="7">Sub Total</th>
+            <th class="text-end" style="color:darkred"><strong>{{ number_format($total_sub, 2) }}</strong></th>
+        </tfoot>
         </table>
     @endif
 
 
 @endforeach
+
+<table class="table table-bordered">
+    <thead style="font-size:20px">
+        <th class="text-start" colspan="7">Grand Total</th>
+        <th class="text-end" style="color:darkred">{{ number_format($total_grand, 2) }}</th>
+    </thead>
+</table>
+
 @endsection

--- a/resources/views/reports/customers/pdf/aged_receivable/detailed.blade.php
+++ b/resources/views/reports/customers/pdf/aged_receivable/detailed.blade.php
@@ -1,0 +1,83 @@
+
+@extends('reports.template')
+@section('page_title', 'Aged Receivables')
+@section('content')
+
+@php
+    $customer_id = 0;
+@endphp
+
+@foreach($results as $result)
+
+    @if($customer_id != $result->customer_id && $customer_id != 0)
+            </tbody>
+            <tfoot>
+                <th class="text-start" colspan="3">Total</th>
+                <th class="text-end">{{ number_format($total_current, 2) }}</th>
+                <th class="text-end">{{ number_format($total_thirty_days, 2) }}</th>
+                <th class="text-end">{{ number_format($total_sixty_days, 2) }}</th>
+                <th class="text-end">{{ number_format($total_ninety_days, 2) }}</th>
+                <th class="text-end">{{ number_format($total_over_ninety_days, 2) }}</th>
+            </tfoot>
+        </table>
+    @endif
+    @if($customer_id != $result->customer_id)
+        <h5 class="text-start" style="font-size:18px;margin-bottom:0px">{{ $result->customer_name }}</h5>
+        @php
+            $customer_id = $result->customer_id;
+            $total_current = floatval(0);
+            $total_thirty_days = floatval(0);
+            $total_sixty_days = floatval(0);    
+            $total_ninety_days = floatval(0);
+            $total_over_ninety_days = floatval(0);
+        @endphp
+
+        <table class="table table-bordered">
+            <thead>
+                <th class="text-start">Date</th>
+                <th class="text-start">Due Date</th>
+                <th class="text-start">Reference</th>
+                <th class="text-end">Current</th>
+                <th class="text-end">30 Days</th>
+                <th class="text-end">60 Days</th>
+                <th class="text-end">90 Days</th>
+                <th class="text-end">Over 90 Days</th>
+            </thead>
+            <tbody>
+    @endif
+
+    <tr>
+        <td class="text-start">{{ $result->date }}</td>
+        <td class="text-start">{{ $result->due_date }}</td>
+        <td class="text-start">{{ $result->receipt_reference_id }}</td>
+        <td class="text-end">{{ number_format($result->current, 2) }}</td>
+        <td class="text-end">{{ number_format($result->thirty_days, 2) }}</td>
+        <td class="text-end">{{ number_format($result->sixty_days, 2) }}</td>
+        <td class="text-end">{{ number_format($result->ninety_days, 2) }}</td>
+        <td class="text-end">{{ number_format($result->over_ninety_days, 2) }}</td>
+    </tr>
+
+    @php
+        $total_current += floatval($result->current);
+        $total_thirty_days += floatval($result->thirty_days);
+        $total_sixty_days += floatval($result->sixty_days);
+        $total_ninety_days += floatval($result->ninety_days);
+        $total_over_ninety_days += floatval($result->over_ninety_days);
+    @endphp
+
+    @if($loop->last)
+        </tbody>
+        <tfoot>
+            <th class="text-start" colspan="3">Total</th>
+            <th class="text-end">{{ number_format($total_current, 2) }}</th>
+            <th class="text-end">{{ number_format($total_thirty_days, 2) }}</th>
+            <th class="text-end">{{ number_format($total_sixty_days, 2) }}</th>
+            <th class="text-end">{{ number_format($total_ninety_days, 2) }}</th>
+            <th class="text-end">{{ number_format($total_over_ninety_days, 2) }}</th>
+        </tfoot>
+        </table>
+    @endif
+
+
+@endforeach
+@endsection

--- a/resources/views/reports/customers/pdf/aged_receivable/summary.blade.php
+++ b/resources/views/reports/customers/pdf/aged_receivable/summary.blade.php
@@ -29,7 +29,7 @@
             <td class="text-end">{{ number_format($customer->sixty_days, 2) }}</td>
             <td class="text-end">{{ number_format($customer->ninety_days, 2) }}</td>
             <td class="text-end">{{ number_format($customer->over_ninety_days, 2) }}</td>
-            <td class="text-end">{{ number_format($customer->total, 2) }}</td>
+            <td class="text-end"><strong>{{ number_format($customer->total, 2) }}</strong></td>
         </tr>
         @php
             $total_current += $customer->current;
@@ -48,7 +48,7 @@
         <th class="text-end">{{ number_format($total_sixty_days, 2) }}</th>
         <th class="text-end">{{ number_format($total_ninety_days, 2) }}</th>
         <th class="text-end">{{ number_format($total_over_ninety_days, 2) }}</th>
-        <th class="text-end">{{ number_format($total_grand, 2) }}</th>
+        <th class="text-end" style="color:darkred">{{ number_format($total_grand, 2) }}</th>
     </tfoot>
 </table>
 @endsection

--- a/resources/views/reports/customers/pdf/aged_receivable/summary.blade.php
+++ b/resources/views/reports/customers/pdf/aged_receivable/summary.blade.php
@@ -1,0 +1,38 @@
+
+@extends('reports.template')
+@section('page_title', 'Aged Receivables')
+@section('content')
+<table class="table table-bordered">
+    <thead>
+        <th class="text-start">Customer</th>
+        <th class="text-end">Current</th>
+        <th class="text-end">30 Days</th>
+        <th class="text-end">60 Days</th>
+        <th class="text-end">90 Days</th>
+        <th class="text-end">Over 90 Days</th>
+        <th class="text-end">Total</th>
+    </thead>
+    <tbody>
+        {{-- @foreach ($customers as $customer) --}}
+        <tr>
+            <td class="text-start">Test Customer{{-- $customer->name --}}</td>
+            <td class="text-end">0.00{{-- $customer->balance --}}</td>
+            <td class="text-end">0.00{{-- $customer->thirty_days --}}</td>
+            <td class="text-end">0.00{{-- $customer->sixty_days --}}</td>
+            <td class="text-end">0.00{{-- $customer->ninety_days --}}</td>
+            <td class="text-end">0.00{{-- $customer->over_ninety_days --}}</td>
+            <td class="text-end">0.00{{-- $customer->total --}}</td>
+        </tr>
+        {{-- @endforeach --}}
+    </tbody>
+    <tfoot>
+        <th class="text-start">Total</th>
+        <th class="text-end">0.00{{-- $total_balance --}}</th>
+        <th class="text-end">0.00{{-- $total_thirty_days --}}</th>
+        <th class="text-end">0.00{{-- $total_sixty_days --}}</th>
+        <th class="text-end">0.00{{-- $total_ninety_days --}}</th>
+        <th class="text-end">0.00{{-- $total_over_ninety_days --}}</th>
+        <th class="text-end">0.00{{-- $total_total --}}</th>
+    </tfoot>
+</table>
+@endsection

--- a/resources/views/reports/customers/pdf/aged_receivable/summary.blade.php
+++ b/resources/views/reports/customers/pdf/aged_receivable/summary.blade.php
@@ -13,26 +13,42 @@
         <th class="text-end">Total</th>
     </thead>
     <tbody>
-        {{-- @foreach ($customers as $customer) --}}
+        @php
+            $total_current = floatval(0);
+            $total_thirty_days = floatval(0);
+            $total_sixty_days = floatval(0);    
+            $total_ninety_days = floatval(0);
+            $total_over_ninety_days = floatval(0);
+            $total_grand = floatval(0);
+        @endphp
+        @foreach ($results as $customer)
         <tr>
-            <td class="text-start">Test Customer{{-- $customer->name --}}</td>
-            <td class="text-end">0.00{{-- $customer->balance --}}</td>
-            <td class="text-end">0.00{{-- $customer->thirty_days --}}</td>
-            <td class="text-end">0.00{{-- $customer->sixty_days --}}</td>
-            <td class="text-end">0.00{{-- $customer->ninety_days --}}</td>
-            <td class="text-end">0.00{{-- $customer->over_ninety_days --}}</td>
-            <td class="text-end">0.00{{-- $customer->total --}}</td>
+            <td class="text-start">{{ $customer->name }}</td>
+            <td class="text-end">{{ number_format($customer->current, 2) }}</td>
+            <td class="text-end">{{ number_format($customer->thirty_days, 2) }}</td>
+            <td class="text-end">{{ number_format($customer->sixty_days, 2) }}</td>
+            <td class="text-end">{{ number_format($customer->ninety_days, 2) }}</td>
+            <td class="text-end">{{ number_format($customer->over_ninety_days, 2) }}</td>
+            <td class="text-end">{{ number_format($customer->total, 2) }}</td>
         </tr>
-        {{-- @endforeach --}}
+        @php
+            $total_current += $customer->current;
+            $total_thirty_days += $customer->thirty_days;
+            $total_sixty_days += $customer->sixty_days;    
+            $total_ninety_days += $customer->ninety_days;
+            $total_over_ninety_days += $customer->over_ninety_days;
+            $total_grand += $customer->total;
+        @endphp
+        @endforeach
     </tbody>
     <tfoot>
         <th class="text-start">Total</th>
-        <th class="text-end">0.00{{-- $total_balance --}}</th>
-        <th class="text-end">0.00{{-- $total_thirty_days --}}</th>
-        <th class="text-end">0.00{{-- $total_sixty_days --}}</th>
-        <th class="text-end">0.00{{-- $total_ninety_days --}}</th>
-        <th class="text-end">0.00{{-- $total_over_ninety_days --}}</th>
-        <th class="text-end">0.00{{-- $total_total --}}</th>
+        <th class="text-end">{{ number_format($total_current, 2) }}</th>
+        <th class="text-end">{{ number_format($total_thirty_days, 2) }}</th>
+        <th class="text-end">{{ number_format($total_sixty_days, 2) }}</th>
+        <th class="text-end">{{ number_format($total_ninety_days, 2) }}</th>
+        <th class="text-end">{{ number_format($total_over_ninety_days, 2) }}</th>
+        <th class="text-end">{{ number_format($total_grand, 2) }}</th>
     </tfoot>
 </table>
 @endsection

--- a/resources/views/reports/template.blade.php
+++ b/resources/views/reports/template.blade.php
@@ -17,7 +17,6 @@
         }
 
         .table-bordered th, .table-bordered td{
-            text-align:left;
             border: 1px solid black;
             border-collapse: collapse;
             padding: 2px;


### PR DESCRIPTION
Aged Receivables' Report will come in two types:
- [x] Summary
- [x] Detailed

Summary will show the sum of receivables per customer. Meanwhile, the detailed type will show the breakdown of receivables by invoice, grouped by customer.

Summary
![image](https://user-images.githubusercontent.com/32955000/187372826-e3be917e-b7b1-4327-981c-53500396c3cc.png)

Detailed
![image](https://user-images.githubusercontent.com/32955000/187372883-027a9a1d-883f-4140-a3ad-a56bd34623ca.png)
_Note: Verla's 1st `due date` set before the actual date was intentional to see how the amount was categorized. This shouldn't be possible when done in the web app._