### PR TITLE
Stream Generated Report PDFs

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -42,82 +42,82 @@ class ReportsController extends Controller
     public function agedReceivablePDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.customers.pdf.aged_receivable', compact('request'));
-        return $pdf->download('aged_receivable.pdf');
+        return $pdf->stream('aged_receivable.pdf');
     }
     
     public function cashReceiptsJournalPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.customers.pdf.cash_receipts_journal', compact('request'));
-        return $pdf->download('cash_receipts_journal.pdf');
+        return $pdf->stream('cash_receipts_journal.pdf');
     }
 
     public function customerLedgersPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.customers.pdf.customers_ledgers', compact('request'));
-        return $pdf->download('customer_ledgers.pdf');
+        return $pdf->stream('customer_ledgers.pdf');
     }
     
     // Vendors
     public function agedPayablesPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.vendors.pdf.aged_payables', compact('request'));
-        return $pdf->download('aged_payables.pdf');
+        return $pdf->stream('aged_payables.pdf');
     }
 
     public function cashDisbursementsJournalPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.vendors.pdf.cash_disbursements_journal', compact('request'));
-        return $pdf->download('cash_disbursements_journal.pdf');
+        return $pdf->stream('cash_disbursements_journal.pdf');
     }
 
     public function cashRequirementsPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.vendors.pdf.cash_requirements', compact('request'));
-        return $pdf->download('cash_requirements.pdf');
+        return $pdf->stream('cash_requirements.pdf');
     }
 
     public function vendorLedgersPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.vendors.pdf.vendor_ledgers', compact('request'));
-        return $pdf->download('vendor_ledgers.pdf');
+        return $pdf->stream('vendor_ledgers.pdf');
     }
 
     // Sales
     public function salesPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.sales.pdf.sales', compact('request'));
-        return $pdf->download('sales.pdf');
+        return $pdf->stream('sales.pdf');
     }
 
     // Entries
     public function generalLedgerPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.entries.pdf.general_ledger', compact('request'));
-        return $pdf->download('general_ledger.pdf');
+        return $pdf->stream('general_ledger.pdf');
     }
 
     public function generalJournalPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.entries.pdf.general_journal', compact('request'));
-        return $pdf->download('general_journal.pdf');
+        return $pdf->stream('general_journal.pdf');
     }
 
     public function receiptPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.entries.pdf.receipt', compact('request'));
-        return $pdf->download('receipt.pdf');
+        return $pdf->stream('receipt.pdf');
     }
 
     public function billPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.entries.pdf.bill', compact('request'));
-        return $pdf->download('bill.pdf');
+        return $pdf->stream('bill.pdf');
     }
     
     public function paymentPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.entries.pdf.payment', compact('request'));
-        return $pdf->download('payment.pdf');
+        return $pdf->stream('payment.pdf');
     }
 
     public function journalVoucherPDF(Request $request)
@@ -128,32 +128,32 @@ class ReportsController extends Controller
         $totalCredit = JournalPostings::where('type', '=', 'credit')->sum('amount'); 
 
         $pdf = \PDF::loadView('reports.entries.pdf.journal_voucher', compact('request','journalVouchers','totalDebit','totalCredit'));
-        return $pdf->download('journal_voucher.pdf');
+        return $pdf->stream('journal_voucher.pdf');
     }
     
     // Financial Statement
     public function balanceSheetPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.financial_statement.pdf.balance_sheet', compact('request'));
-        return $pdf->download('balance_sheet.pdf');
+        return $pdf->stream('balance_sheet.pdf');
     }
 
     public function balanceSheetZeroAccountPDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.financial_statement.pdf.balance_sheet_zero_account', compact('request'));
-        return $pdf->download('balance_sheet_zero_account.pdf');
+        return $pdf->stream('balance_sheet_zero_account.pdf');
     }
     
     public function incomeStatementSinglePDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.financial_statement.pdf.income_statement_single', compact('request'));
-        return $pdf->download('income_statement_single.pdf');
+        return $pdf->stream('income_statement_single.pdf');
     }
 
     public function incomeStatementMultiplePDF(Request $request)
     {
         $pdf = \PDF::loadView('reports.financial_statement.pdf.income_statement_multiple', compact('request'));
-        return $pdf->download('income_statement_multiple.pdf');
+        return $pdf->stream('income_statement_multiple.pdf');
     }
 
   

--- a/resources/views/reports/customers/index.blade.php
+++ b/resources/views/reports/customers/index.blade.php
@@ -30,7 +30,7 @@
             <!--Bill Payment content--->
             <div class="tab-pane fade show active aged_receivable">
 
-                <form action="{{route('reports.aged_receivable.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.aged_receivable.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">
@@ -63,7 +63,7 @@
             <!--Other Payment content--->
             <div class="tab-pane fade cash_receipts_journal">
                 
-                <form action="{{route('reports.cash_receipts_journal.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.cash_receipts_journal.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-md-6">
@@ -94,7 +94,7 @@
             </div>
             <div class="tab-pane fade customer_ledgers">
                 
-                <form action="{{route('reports.customer_ledgers.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.customer_ledgers.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-md-6">

--- a/resources/views/reports/entries/index.blade.php
+++ b/resources/views/reports/entries/index.blade.php
@@ -40,7 +40,7 @@
         <div class="card-body tab-content">
 
             <div class="tab-pane fade show active general_ledger">
-                <form action="{{route('reports.general_ledger.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.general_ledger.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">
@@ -70,7 +70,7 @@
             </div>
 
             <div class="tab-pane fade general_journal">
-                <form action="{{route('reports.general_journal.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.general_journal.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">
@@ -100,7 +100,7 @@
             </div>
 
             <div class="tab-pane fade receipt">
-                <form action="{{route('reports.receipt.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.receipt.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">
@@ -130,7 +130,7 @@
             </div>
             
             <div class="tab-pane fade bill">
-                <form action="{{route('reports.bill.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.bill.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">
@@ -160,7 +160,7 @@
             </div>
             
             <div class="tab-pane fade payment">
-                <form action="{{route('reports.payment.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.payment.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">
@@ -190,7 +190,7 @@
             </div>
 
             <div class="tab-pane fade journal_voucher">
-                <form action="{{route('reports.journal_voucher.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.journal_voucher.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">

--- a/resources/views/reports/financial_statement/index.blade.php
+++ b/resources/views/reports/financial_statement/index.blade.php
@@ -31,7 +31,7 @@
         <div class="card-body tab-content">
 
             <div class="tab-pane fade show balance_sheet_zero_account">
-                <form action="{{route('reports.balance_sheet_zero_account.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.balance_sheet_zero_account.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">
@@ -61,7 +61,7 @@
             </div>
 
             <div class="tab-pane fade show active balance_sheet">
-                <form action="{{route('reports.balance_sheet.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.balance_sheet.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">
@@ -91,7 +91,7 @@
             </div>
 
             <div class="tab-pane fade show income_statement_single">
-                <form action="{{route('reports.income_statement_single.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.income_statement_single.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">
@@ -121,7 +121,7 @@
             </div>
 
             <div class="tab-pane fade show income_statement_multiple">
-                <form action="{{route('reports.income_statement_multiple.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.income_statement_multiple.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">

--- a/resources/views/reports/sales/index.blade.php
+++ b/resources/views/reports/sales/index.blade.php
@@ -19,7 +19,7 @@
         <div class="card-body tab-content">
 
             <div class="tab-pane fade show active sales">
-                <form action="{{route('reports.sales.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.sales.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">

--- a/resources/views/reports/vendors/index.blade.php
+++ b/resources/views/reports/vendors/index.blade.php
@@ -32,7 +32,7 @@
         <div class="card-body tab-content">
 
             <div class="tab-pane fade show active aged_payables">
-                <form action="{{route('reports.aged_payables.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.aged_payables.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">
@@ -62,7 +62,7 @@
             </div>
 
             <div class="tab-pane fade cash_disbursements_journal">
-                <form action="{{route('reports.cash_disbursements_journal.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.cash_disbursements_journal.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">
@@ -92,7 +92,7 @@
             </div>
 
             <div class="tab-pane fade vendor_ledgers">
-                <form action="{{route('reports.vendor_ledgers.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.vendor_ledgers.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">
@@ -122,7 +122,7 @@
             </div>
             
             <div class="tab-pane fade cash_requirements">
-                <form action="{{route('reports.cash_requirements.pdf')}}" method="POST">
+                <form target="_blank" action="{{route('reports.cash_requirements.pdf')}}" method="POST">
                     @csrf
                     <div class="row">
                         <div class="col-xl-6">


### PR DESCRIPTION
This pull request modifies the `ReportsController` to stream the generated reports' PDF instead of downloading them.
Before:
```php
return $pdf->download('aged_receivable.pdf');
```
After:
```php
return $pdf->stream('aged_receivable.pdf');
```

In line with this change is also the behavior of generating a report. When generating a report, it will redirect to the generated pdf. Opening a new tab will help the user easily switch back to the report generation page without leaving the generated report's tab.