### PR TITLE
Link `void` functionality of `Receipt` to COA

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -295,6 +295,7 @@ class ReportsController extends Controller
                 ->whereBetween('date', [$request->date_from, $request->date_to])
                 ->where('chart_of_accounts.id', '=', $r[$i]->coa_id)
                 ->where('journal_postings.type', 'debit')
+                ->where('journal_entries.is_void', false)
                 ->get();
 
             $jp_c[$i] = DB::table('journal_entries')
@@ -305,10 +306,11 @@ class ReportsController extends Controller
                 )
                 ->leftJoin('journal_postings', 'journal_entries.id', '=', 'journal_postings.journal_entry_id')
                 ->leftJoin('chart_of_accounts', 'journal_postings.chart_of_account_id', '=', 'chart_of_accounts.id')
-                ->orderBy('journal_entries.date', 'asc')
                 ->whereBetween('date', [$request->date_from, $request->date_to])
                 ->where('chart_of_accounts.id', '=', $r[$i]->coa_id)
                 ->where('journal_postings.type', 'credit')
+                ->where('journal_entries.is_void', false)
+                ->orderBy('journal_entries.date', 'asc')
                 ->get();
         }
 
@@ -333,10 +335,11 @@ class ReportsController extends Controller
                 DB::raw("CASE WHEN journal_postings.type = 'debit' THEN journal_postings.amount ELSE 0 END AS 'debit'"),
                 DB::raw("CASE WHEN journal_postings.type = 'credit' THEN journal_postings.amount ELSE 0 END AS 'credit'"),
             )
-            ->whereBetween('date', [$request->date_from, $request->date_to])
-            ->where('journal_entries.accounting_system_id', '=', session('accounting_system_id'))
             ->leftJoin('journal_postings', 'journal_entries.id', '=', 'journal_postings.journal_entry_id')
             ->leftJoin('chart_of_accounts', 'journal_postings.chart_of_account_id', '=', 'chart_of_accounts.id')
+            ->whereBetween('date', [$request->date_from, $request->date_to])
+            ->where('journal_entries.accounting_system_id', '=', session('accounting_system_id'))
+            ->where('journal_entries.is_void', false)
             ->orderBy('journal_entries.date', 'asc')
             ->get();
 
@@ -419,6 +422,7 @@ class ReportsController extends Controller
             ->leftJoin('chart_of_accounts', 'chart_of_accounts.id', '=', 'journal_postings.chart_of_account_id')
             ->whereBetween('date', [$request->date_from, $request->date_to])
             ->where('journal_entries.accounting_system_id', session('accounting_system_id'))
+            ->where('journal_entries.is_void', false)
             ->orderBy('journal_vouchers.id')
             ->get();
 

--- a/app/Http/Controllers/Settings/ChartOfAccountsController.php
+++ b/app/Http/Controllers/Settings/ChartOfAccountsController.php
@@ -28,17 +28,23 @@ class ChartOfAccountsController extends Controller
     {
         $accounting_system_id = $this->request->session()->get('accounting_system_id');
 
-        $sum_debits = JournalPostings::select(
-                'chart_of_account_id',
-                DB::raw('SUM(amount) as total_debit'),
+        $sum_debits = DB::table('journal_postings')
+            ->select(
+                'journal_postings.chart_of_account_id',
+                DB::raw('SUM(journal_postings.amount) as total_debit'),
             )
+            ->leftJoin('journal_entries', 'journal_postings.journal_entry_id', '=', 'journal_entries.id')
+            ->where('journal_entries.is_void', false)
             ->where('type', 'debit')
             ->groupBy('chart_of_account_id');
 
-        $sum_credits = JournalPostings::select(
-                'chart_of_account_id',
-                DB::raw('SUM(amount) as total_credit'),
+        $sum_credits = DB::table('journal_postings')
+            ->select(
+                'journal_postings.chart_of_account_id',
+                DB::raw('SUM(journal_postings.amount) as total_credit'),
             )
+            ->leftJoin('journal_entries', 'journal_postings.journal_entry_id', '=', 'journal_entries.id')
+            ->where('journal_entries.is_void', false)
             ->where('type', 'credit')
             ->groupBy('chart_of_account_id');
 

--- a/app/Models/ReceiptReferences.php
+++ b/app/Models/ReceiptReferences.php
@@ -12,6 +12,7 @@ class ReceiptReferences extends Model
 
     protected $fillable = [
         'accounting_system_id',
+        'journal_entry_id',
         'reference_number',
         'date',
         'type',
@@ -51,7 +52,7 @@ class ReceiptReferences extends Model
     }
     public function journalEntry()
     {
-        return $this->hasOne(JournalEntries::class, 'model_reference_id','id');
+        return $this->hasOne(JournalEntries::class, 'id', 'journal_entry_id');
     }
     public function receiptItems()
     {

--- a/app/Models/Settings/ChartOfAccounts/JournalEntries.php
+++ b/app/Models/Settings/ChartOfAccounts/JournalEntries.php
@@ -17,6 +17,7 @@ class JournalEntries extends Model
         'accounting_system_id',
         'date',
         'notes',
+        'is_void',
     ];
 
     public function journalPostings()

--- a/database/migrations/2022_06_11_130227_update_journal_entries_void.php
+++ b/database/migrations/2022_06_11_130227_update_journal_entries_void.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateJournalEntriesVoid extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Update accounting_systems schema
+        Schema::table('journal_entries', function (Blueprint $table) {
+            $table->boolean('is_void')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2022_06_11_130227_update_receipt_references_journal_entry_id.php
+++ b/database/migrations/2022_06_11_130227_update_receipt_references_journal_entry_id.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateReceiptReferencesJournalEntryId extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Update accounting_systems schema
+        Schema::table('receipt_references', function (Blueprint $table) {
+            $table->foreignId('journal_entry_id')->nullable()->constrained();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
### Receipt
Before Void:
![image](https://user-images.githubusercontent.com/32955000/188262908-86be16a2-c827-4cdb-956f-9e74236ccf41.png)

After Void:
![image](https://user-images.githubusercontent.com/32955000/188262920-f7abda9e-30e6-4eca-900a-03214ae93a1d.png)

### Advance Revenue
Before Void:
![image](https://user-images.githubusercontent.com/32955000/188262929-de78673a-d3ea-4294-a1d2-9735d7d0b79a.png)

After Void:
![image](https://user-images.githubusercontent.com/32955000/188262938-75ee1c88-0ac1-4d8d-8d95-42417dbf1b35.png)


### Credit Receipt
Before Void:
[Before Paid]
![image](https://user-images.githubusercontent.com/32955000/188262956-e84457af-e365-4caf-b6a4-a9d0b8e0a102.png)

[After Paid]
![image](https://user-images.githubusercontent.com/32955000/188263086-b49f4096-e75f-4681-bebb-3a55681ca5fa.png)

After Void:
![image](https://user-images.githubusercontent.com/32955000/188263330-067df942-c5ec-4622-9eda-fc23d2d04ca6.png)

