### PR TITLE
Fix typo in `StoreJournalVoucherRequest` class

### DIFF
--- a/app/Http/Requests/StoreJournalVoucherRequest.php
+++ b/app/Http/Requests/StoreJournalVoucherRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests;
 
-use App\Http\requests\Api\FormRequest;
+use App\Http\Requests\Api\FormRequest;
 use App\Actions\DecodeTagifyField;
 
 class StoreJournalVoucherRequest extends FormRequest


### PR DESCRIPTION
Confirmed that the issue from #206 in testing server is caused by a typo as evident in the changes. It turns out that the testing server is strict in regards to case-sensitivity in namespaces and classes as it wasn't the case in the local server.

![image](https://user-images.githubusercontent.com/32955000/192665863-4953585d-90bf-471d-bdc0-8a8b9af15ee8.png)

Closes #206 
