### PR TITLE
Implement `Quick New` Transactions

### DIFF
--- a/public/js/quick-new-shortcut.js
+++ b/public/js/quick-new-shortcut.js
@@ -12,3 +12,32 @@ $(document).ready(function(){
         }
     }
 });
+
+$(document).on('click', '.quick-new-link', function(e){
+    e.preventDefault();
+
+    let currentUrl = window.location.href.split('?')[0];
+    let redirectUrl = $(this).attr('href');
+    let redirectUrlParams = new URLSearchParams(redirectUrl.split('?')[1]);
+    let redirectPathName = $(this)[0].pathname;
+
+    console.log(window.location.pathname);
+    console.log(redirectPathName);
+
+    // If the current page is the same as the page we're redirecting to, just open the modal
+    if(window.location.pathname == redirectPathName) {
+        for(let pair of redirectUrlParams.entries()) {
+            console.log("Key is:" + pair[0]);
+            console.log("Value is:" + pair[1]);
+    
+            if(pair[0] == "new") {
+                $(`#${pair[1]}`).modal('show');
+                console.log(`Opening modal for #${pair[1]}`);
+            }
+        }
+    }
+    // Otherwise, redirect to the page. The modal will open automatically.
+    else {
+        window.location.href = redirectUrl;
+    }
+})

--- a/public/js/quick-new-shortcut.js
+++ b/public/js/quick-new-shortcut.js
@@ -1,0 +1,14 @@
+$(document).ready(function(){
+    let urlString = window.location.href;
+    let paramString = urlString.split('?')[1];
+    let queryString = new URLSearchParams(paramString);
+    for(let pair of queryString.entries()) {
+        console.log("Key is:" + pair[0]);
+        console.log("Value is:" + pair[1]);
+
+        if(pair[0] == "new") {
+            $(`#${pair[1]}`).modal('show');
+            console.log(`Opening modal for #${pair[1]}`);
+        }
+    }
+});

--- a/resources/views/template/header.blade.php
+++ b/resources/views/template/header.blade.php
@@ -26,6 +26,28 @@
         <script type="text/javascript" src="//cdn.jsdelivr.net/momentjs/latest/moment.min.js"></script> 
         <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
 
+    <style>
+      .dropdown-menu-quick-new {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        z-index: 1000000!important;
+        display: none;
+        float: left;
+        min-width: 40rem!important;
+        padding: 1rem 0;
+        margin: 0.125rem 0.125rem 0 0!important;
+        font-size: 0.85rem;
+        color: #858796;
+        text-align: left;
+        list-style: none;
+        background-color: #fff;
+        background-clip: padding-box;
+        border: 1px solid #e3e6f0;
+        border-radius: 0.35rem;
+      }
+    </style>
+
     @stack('styles')
     
 </head>

--- a/resources/views/template/navbar.blade.php
+++ b/resources/views/template/navbar.blade.php
@@ -155,28 +155,28 @@
                                 <div class="row">
                                     <div class="col-12 col-md-6 col-lg-4">
                                         <h6>Customers</h6>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/customers/customers?new=modal-customer') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/customers/customers?new=modal-customer') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Customer
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/customers/deposits?new=modal-deposit') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/customers/deposits?new=modal-deposit') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Deposit
                                         </a>
                                         <p class="my-2"><strong>Receipt</strong></p>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/customers/receipts?new=modal-receipt') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/customers/receipts?new=modal-receipt') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Receipt
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/customers/receipts?new=modal-advance-revenue') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/customers/receipts?new=modal-advance-revenue') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Advance Revenue
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/customers/receipts?new=modal-credit-receipt') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/customers/receipts?new=modal-credit-receipt') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Credit Receipt
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/customers/receipts?new=modal-proforma') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/customers/receipts?new=modal-proforma') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Proforma
                                         </a>
@@ -184,73 +184,73 @@
                                     </div>
                                     <div class="col-12 col-md-6 col-lg-4">
                                         <h6>Vendors</h6>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/vendors?new=new_vendor_modal') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/vendors/vendors?new=new_vendor_modal') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Vendor
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/bills?new=modal-bill') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/vendors/bills?new=modal-bill') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Bill
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/bills?new=modal-purchase-order') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/vendors/bills?new=modal-purchase-order') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Purchase Order
                                         </a>
                                         <p class="my-2"><strong>Payment</strong></p>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-bill-payment') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/vendors/payments?new=modal-bill-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Bill Payment
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-vat-payment') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/vendors/payments?new=modal-vat-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             VAT Payment
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-withholding-payment') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/vendors/payments?new=modal-withholding-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Withholding Payment
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-payroll-payment') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/vendors/payments?new=modal-payroll-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Payroll Payment
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-income-tax-payment') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/vendors/payments?new=modal-income-tax-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Income Tax Payment
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-pension-payment') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/vendors/payments?new=modal-pension-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Pension Payment
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-commission-payment') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/vendors/payments?new=modal-commission-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Commission Payment
                                         </a>
                                     </div>
                                     <div class="col-12 col-md-6 col-lg-4">
                                         <h6>Journal Vouchers</h6>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/jv?new=modal-jv') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/jv?new=modal-jv') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Journal Voucher
                                         </a>
                                         <h6 class="mt-2">Human Resource</h6>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/hr/addition?new=modal-addition') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/hr/addition?new=modal-addition') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Addition
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/hr/deduction?new=modal-deduction') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/hr/deduction?new=modal-deduction') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Deduction
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/hr/loan?new=modal-loan') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/hr/loan?new=modal-loan') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Loan
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/hr/overtime?new=modal-overtime') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/hr/overtime?new=modal-overtime') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Overtime
                                         </a>
                                         <h6 class="mt-2">Inventory</h6>
-                                        <a class="dropdown-item rounded px-2" href="{{ url('/inventory?new=modal-new-item') }}">
+                                        <a class="dropdown-item rounded px-2 quick-new-link" href="{{ url('/inventory?new=modal-new-item') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Item
                                         </a>

--- a/resources/views/template/navbar.blade.php
+++ b/resources/views/template/navbar.blade.php
@@ -155,28 +155,28 @@
                                 <div class="row">
                                     <div class="col-12 col-md-6 col-lg-4">
                                         <h6>Customers</h6>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/customers/customers?new=modal-customer') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Customer
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/customers/deposits?new=modal-deposit') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Deposit
                                         </a>
                                         <p class="my-2"><strong>Receipt</strong></p>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/customers/receipts?new=modal-receipt') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Receipt
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/customers/receipts?new=modal-advance-revenue') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Advance Revenue
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/customers/receipts?new=modal-credit-receipt') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Credit Receipt
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/customers/receipts?new=modal-proforma') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Proforma
                                         </a>
@@ -184,66 +184,75 @@
                                     </div>
                                     <div class="col-12 col-md-6 col-lg-4">
                                         <h6>Vendors</h6>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/vendors?new=new_vendor_modal') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Vendor
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/bills?new=modal-bill') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Bill
                                         </a>
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/bills?new=modal-purchase-order') }}">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Purchase Order
+                                        </a>
                                         <p class="my-2"><strong>Payment</strong></p>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-bill-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Bill Payment
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-vat-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             VAT Payment
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-withholding-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Withholding Payment
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-payroll-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Payroll Payment
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-income-tax-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
-                                            Income Payment
+                                            Income Tax Payment
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-pension-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Pension Payment
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/vendors/payments?new=modal-commission-payment') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Commission Payment
                                         </a>
                                     </div>
                                     <div class="col-12 col-md-6 col-lg-4">
                                         <h6>Journal Vouchers</h6>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/jv?new=modal-jv') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Journal Voucher
                                         </a>
                                         <h6 class="mt-2">Human Resource</h6>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/hr/addition?new=modal-addition') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Addition
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/hr/deduction?new=modal-deduction') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Deduction
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/hr/loan?new=modal-loan') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Loan
                                         </a>
-                                        <a class="dropdown-item rounded px-2" href="#">
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/hr/overtime?new=modal-overtime') }}">
                                             <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
                                             Overtime
+                                        </a>
+                                        <h6 class="mt-2">Inventory</h6>
+                                        <a class="dropdown-item rounded px-2" href="{{ url('/inventory?new=modal-new-item') }}">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Item
                                         </a>
                                     </div>
                                 </div>

--- a/resources/views/template/navbar.blade.php
+++ b/resources/views/template/navbar.blade.php
@@ -142,7 +142,117 @@
                     </button>
 
                     <!-- Topbar Accounting System Name & Year -->
-                    <div>
+                    <div class="dropdown">
+                        <button class="btn btn-primary mr-3 dropdown-toggle" type="button"
+                        data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <i class="fas fa-fw fa-pen"></i>
+                            <span class="text">Quick New</span>
+                        </button>
+                            <!-- Dropdown - User Information -->
+                        <div class="dropdown-menu dropdown-menu-quick-new dropdown-menu-left shadow animated--grow-in"
+                            aria-labelledby="new_transactions">
+                            <div class="container-fluid">
+                                <div class="row">
+                                    <div class="col-12 col-md-6 col-lg-4">
+                                        <h6>Customers</h6>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Customer
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Deposit
+                                        </a>
+                                        <p class="my-2"><strong>Receipt</strong></p>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Receipt
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Advance Revenue
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Credit Receipt
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Proforma
+                                        </a>
+                                        
+                                    </div>
+                                    <div class="col-12 col-md-6 col-lg-4">
+                                        <h6>Vendors</h6>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Vendor
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Bill
+                                        </a>
+                                        <p class="my-2"><strong>Payment</strong></p>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Bill Payment
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            VAT Payment
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Withholding Payment
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Payroll Payment
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Income Payment
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Pension Payment
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Commission Payment
+                                        </a>
+                                    </div>
+                                    <div class="col-12 col-md-6 col-lg-4">
+                                        <h6>Journal Vouchers</h6>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Journal Voucher
+                                        </a>
+                                        <h6 class="mt-2">Human Resource</h6>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Addition
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Deduction
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Loan
+                                        </a>
+                                        <a class="dropdown-item rounded px-2" href="#">
+                                            <i class="fas fa-fw fa-pen fa-sm fa-fw mr-2 text-gray-400"></i>
+                                            Overtime
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+
+                    <div class="d-none d-lg-block">
                         <strong>
                             {{ $accounting_system->accounting_year}}
                              - 

--- a/resources/views/template/script.blade.php
+++ b/resources/views/template/script.blade.php
@@ -36,6 +36,7 @@
     <script src="{{ url('/js/toast.js') }}"></script>
     <script src="{{ url('/js/form-submit-ajax.js') }}"></script>
     <script src="{{ url('/js/ajax-submit-updated.js') }}"></script>
+    <script src="{{ url('/js/quick-new-shortcut.js') }}"></script>
 
        <!-- Dump all dynamic scripts into template -->
         @stack('scripts')

--- a/resources/views/vendors/bills/index.blade.php
+++ b/resources/views/vendors/bills/index.blade.php
@@ -333,7 +333,7 @@
 
 {{-- Modal Contents --}}
 <!--------For add bill--->
-<div class="modal fade bd-example-modal-xl" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
+<div class="modal fade bd-example-modal-xl" id="modal-bill" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
     aria-hidden="true">
     <div class="modal-dialog modal-xl">
         <div class="modal-content">
@@ -352,7 +352,7 @@
     </div>
 </div>
 <!--------For purchase order--->
-<div class="modal fade bd-purchaseOrder-modal-xl" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
+<div class="modal fade bd-purchaseOrder-modal-xl" id="modal-purchase-order" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
     aria-hidden="true">
     <div class="modal-dialog modal-xl">
         <div class="modal-content">

--- a/resources/views/vendors/payments/payment.blade.php
+++ b/resources/views/vendors/payments/payment.blade.php
@@ -135,7 +135,7 @@
 
     {{-- Modals --}}
     {{-- BillPayment --}}
-    <div class="modal fade bill-payment-modal" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
+    <div class="modal fade bill-payment-modal" id="modal-bill-payment" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
         aria-hidden="true">
         <div class="modal-dialog modal-xl">
             <div class="modal-content">
@@ -159,7 +159,7 @@
         </div>
     </div>
     {{-- VAT --}}
-    <div class="modal fade VAT-payment-modal" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
+    <div class="modal fade VAT-payment-modal" id="modal-vat-payment" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
         aria-hidden="true">
         <div class="modal-dialog modal-xl">
             <div class="modal-content">
@@ -182,7 +182,7 @@
         </div>
     </div>
     {{-- Withholding --}}
-    <div class="modal fade Withholding-payment-modal" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
+    <div class="modal fade Withholding-payment-modal" id="modal-withholding-payment" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
         aria-hidden="true">
         <div class="modal-dialog modal-xl">
             <div class="modal-content">
@@ -207,7 +207,7 @@
         </div>
     </div>
     {{-- Payroll --}}
-    <div class="modal fade payroll-payment-modal" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
+    <div class="modal fade payroll-payment-modal" id="modal-payroll-payment" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
         aria-hidden="true">
         <div class="modal-dialog modal-xl">
             <div class="modal-content">
@@ -230,7 +230,7 @@
         </div>
     </div>
     {{-- Income TAX --}}
-    <div class="modal fade income-tax-payment-modal" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
+    <div class="modal fade income-tax-payment-modal" id="modal-income-tax-payment" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
         aria-hidden="true">
         <div class="modal-dialog modal-xl">
             <div class="modal-content">
@@ -255,7 +255,7 @@
         </div>
     </div>
     {{-- Pension --}}
-    <div class="modal fade pension-payment-modal" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
+    <div class="modal fade pension-payment-modal" id="modal-pension-payment" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
         aria-hidden="true">
         <div class="modal-dialog modal-xl">
             <div class="modal-content">
@@ -280,7 +280,7 @@
         </div>
     </div>
     {{-- Commission --}}
-    <div class="modal fade commission-payment-modal" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
+    <div class="modal fade commission-payment-modal" id="modal-commission-payment" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel"
         aria-hidden="true">
         <div class="modal-dialog modal-xl">
             <div class="modal-content">


### PR DESCRIPTION
Navigating through the `Quick New` will redirect the user to its page and automatically shows its respective modal. It serves like a shortcut in attempt to minimize the number of clicks.

See Quick New Transaction Dropdown in Action:
https://user-images.githubusercontent.com/32955000/193379503-9af24f18-19b0-4bb0-b653-724492829ce8.mp4

Todo:
- [x] Create static layout
- [x] Redirect buttons to respective page and launch modal
       - preferably without loading when on its actual page (e.g. receipt index)

Closes #181