### PR TITLE
Fix Potential Issues involving Withholding and Credit Receipts/Bill Payments

### DIFF
--- a/app/Http/Requests/Customer/Receipt/StoreReceiptRequest.php
+++ b/app/Http/Requests/Customer/Receipt/StoreReceiptRequest.php
@@ -141,9 +141,13 @@ class StoreReceiptRequest extends FormRequest
             //     $validator->errors()->add('total_amount_received', 'You have enabled withholding for this receipt. Please pay at least the withholding amount to proceed.');
             // }
 
-            // Check in case of withholding more than grand_total
-            if($this->get('withholding_check') != null && $this->get('grand_total') < $this->get('withholding')) {
-                $validator->errors()->add('withholding', 'Please enter a valid withholding amount. It should not be more than the grand total.');
+            // Check in case of withholding more than sub_total
+            if($this->get('withholding_check') != null && $this->get('withholding') > $this->get('sub_total')) {
+                $validator->errors()->add('withholding', 'Please enter a valid withholding amount. It should not be more than the sub total.');
+            }
+            // Check in case of withholding more than total_amount_received
+            if($this->get('withholding_check') != null && $this->get('withholding') > $this->get('total_amount_received')) {
+                $validator->errors()->add('withholding', 'Please enter a valid withholding amount. It should not be more than the total amount received.');
             }
         });
     }

--- a/app/Http/Requests/Vendor/Bill/StoreBillRequest.php
+++ b/app/Http/Requests/Vendor/Bill/StoreBillRequest.php
@@ -111,6 +111,10 @@ class StoreBillRequest extends FormRequest
             if($this->get('withholding_check') != null && $this->get('withholding') > $this->get('sub_total')) {
                 $validator->errors()->add('withholding', 'Please enter a valid withholding amount. It should not be more than the sub total.');
             }
+            // Check in case of withholding more than total_amount_received
+            if($this->get('withholding_check') != null && $this->get('withholding') > $this->get('total_amount_received')) {
+                $validator->errors()->add('withholding', 'Please enter a valid withholding amount. It should not be more than the total amount received.');
+            }
         });
     }
 }


### PR DESCRIPTION
When withholding is set more than total amount received, it will automatically deduct from the account receivable/account payable.

Assuming this scenario:
![image](https://user-images.githubusercontent.com/32955000/193366948-ac2904a7-db31-4d72-a39c-d43e93f7943c.png)

In the bill, the account payable is supposed to be 393.80, since this is an unpaid bill. If this bill will be paid in full, the account payable may become -200.00, hence the potential miscalculation.

--

Another is when the Withholding is set above the Sub Total. The Grand Total is inclusive of Tax while Sub Total does not. If it goes above Sub Total, the tax may be deducted. Though such a scenario is impractically impossible in real life, such a scenario may happen as users are free to manually input withholding amount.
