### PR TITLE
Make data types of currency values consistent to `decimal(18, 8)`

### DIFF
--- a/database/migrations/2022_03_10_012743_create_taxes_table.php
+++ b/database/migrations/2022_03_10_012743_create_taxes_table.php
@@ -17,7 +17,7 @@ class CreateTaxesTable extends Migration
             $table->id();
             $table->foreignId('accounting_system_id')->constrained();
             $table->string('name');
-            $table->float('percentage');
+            $table->decimal('percentage', 18, 8);
             $table->timestamps();
         });
     }

--- a/database/migrations/2022_03_10_035038_create_inventories_table.php
+++ b/database/migrations/2022_03_10_035038_create_inventories_table.php
@@ -18,8 +18,8 @@ class CreateInventoriesTable extends Migration
             $table->foreignId('accounting_system_id')->constrained();
             $table->string('item_code');
             $table->string('item_name'); 
-            $table->float('sale_price')->nullable();
-            $table->float('purchase_price')->nullable();
+            $table->decimal('sale_price', 18, 8)->nullable();
+            $table->decimal('purchase_price', 18, 8)->nullable();
             $table->integer('quantity')->nullable();
             $table->integer('critical_quantity')->nullable();
             // $table->float('sold_quantity')->nullable();

--- a/database/migrations/2022_03_12_135618_create_chart_of_accounts_table.php
+++ b/database/migrations/2022_03_12_135618_create_chart_of_accounts_table.php
@@ -19,7 +19,7 @@ class CreateChartOfAccountsTable extends Migration
             $table->string('chart_of_account_category_id');
             $table->string('chart_of_account_no');
             $table->string('account_name');
-            $table->float('current_balance')->default(0.00); 
+            $table->decimal('current_balance', 18, 8)->default(0.00); 
             $table->enum('status',['Active','Closed'])->default('Active');
             $table->timestamps();
         });

--- a/database/migrations/2022_03_12_140648_create_period_of_accounts_table.php
+++ b/database/migrations/2022_03_12_140648_create_period_of_accounts_table.php
@@ -17,8 +17,8 @@ class CreatePeriodOfAccountsTable extends Migration
             $table->id();
             $table->foreignId('chart_of_account_id')->constrained(); 
             $table->foreignId('accounting_period_id')->constrained();
-            $table->float('beginning_balance')->nullable();
-            $table->float('closing_balance')->nullable();
+            $table->decimal('beginning_balance', 18, 8)->nullable();
+            $table->decimal('closing_balance', 18, 8)->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2022_03_12_142856_create_journal_postings_table.php
+++ b/database/migrations/2022_03_12_142856_create_journal_postings_table.php
@@ -19,9 +19,8 @@ class CreateJournalPostingsTable extends Migration
             $table->unsignedBigInteger('journal_entry_id');     
             $table->unsignedBigInteger('chart_of_account_id');     
             $table->enum('type',['credit','debit']);
-            $table->float('amount');
+            $table->decimal('amount', 18, 8);
             $table->timestamps();
-
             $table->foreign('journal_entry_id')->references('id')->on('journal_entries')->onDelete('cascade');
             $table->foreign('chart_of_account_id')->references('id')->on('chart_of_accounts');
         });

--- a/database/migrations/2022_03_12_151738_create_receipt_items_table.php
+++ b/database/migrations/2022_03_12_151738_create_receipt_items_table.php
@@ -18,8 +18,8 @@ class CreateReceiptItemsTable extends Migration
             $table->unsignedBigInteger('inventory_id');
             $table->unsignedBigInteger('receipt_reference_id'); 
             $table->integer('quantity'); 
-            $table->float('price')->nullable();
-            $table->float('total_price')->nullable();
+            $table->decimal('price', 18, 8)->nullable();
+            $table->decimal('total_price', 18, 8)->nullable();
             $table->timestamps();
 
             $table->foreign('inventory_id')->references('id')->on('inventories');

--- a/database/migrations/2022_03_12_153132_create_receipt_cash_transactions_table.php
+++ b/database/migrations/2022_03_12_153132_create_receipt_cash_transactions_table.php
@@ -18,7 +18,7 @@ class CreateReceiptCashTransactionsTable extends Migration
             $table->foreignId('accounting_system_id')->constrained();
             $table->foreignId('receipt_reference_id')->constrained();
             $table->unsignedBigInteger('for_receipt_reference_id')->nullable();
-            $table->float('amount_received');
+            $table->decimal('amount_received', 18, 8);
             $table->enum('is_deposited',['yes','no'])->default('no');
             $table->timestamps();
 

--- a/database/migrations/2022_03_12_154516_create_advance_revenues_table.php
+++ b/database/migrations/2022_03_12_154516_create_advance_revenues_table.php
@@ -16,7 +16,7 @@ class CreateAdvanceRevenuesTable extends Migration
         Schema::create('advance_revenues', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('receipt_reference_id');
-            $table->float('total_amount_received');
+            $table->decimal('total_amount_received', 18, 8);
             $table->longText('reason')->nullable();
             $table->longText('remark')->nullable();
             $table->string('attachment')->nullable();

--- a/database/migrations/2022_03_12_155029_create_credit_receipts_table.php
+++ b/database/migrations/2022_03_12_155029_create_credit_receipts_table.php
@@ -16,7 +16,7 @@ class CreateCreditReceiptsTable extends Migration
         Schema::create('credit_receipts', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('receipt_reference_id');
-            $table->float('total_amount_received');
+            $table->decimal('total_amount_received', 18, 8);
             $table->longText('description')->nullable();
             $table->longText('remark')->nullable();
             $table->string('attachment')->nullable();

--- a/database/migrations/2022_03_12_155030_create_proformas_table.php
+++ b/database/migrations/2022_03_12_155030_create_proformas_table.php
@@ -17,10 +17,10 @@ class CreateProformasTable extends Migration
             $table->id();
             $table->unsignedBigInteger('receipt_reference_id');
             $table->date('due_date');
-            $table->float('amount');
-            $table->float('tax');
-            $table->float('sub_total');
-            $table->float('grand_total');
+            $table->decimal('amount', 18, 8);
+            $table->decimal('tax', 18, 8);
+            $table->decimal('sub_total', 18, 8);
+            $table->decimal('grand_total', 18, 8);
             $table->longText('terms_and_conditions')->nullable();
             $table->string('attachment')->nullable();
             $table->timestamps();

--- a/database/migrations/2022_03_12_155657_create_receipts_table.php
+++ b/database/migrations/2022_03_12_155657_create_receipts_table.php
@@ -19,12 +19,12 @@ class CreateReceiptsTable extends Migration
             $table->unsignedBigInteger('proforma_id')->nullable();
             $table->foreignid('chart_of_account_id')->nullable()->constrained();
             $table->date('due_date');
-            $table->float('sub_total');
-            $table->float('discount')->nullable();
-            $table->float('tax')->nullable();
-            $table->float('grand_total');
-            $table->float('total_amount_received');
-            $table->float('withholding')->nullable();
+            $table->decimal('sub_total', 18, 8);
+            $table->decimal('discount', 18, 8)->nullable();
+            $table->decimal('tax', 18, 8)->nullable();
+            $table->decimal('grand_total', 18, 8);
+            $table->decimal('total_amount_received', 18, 8);
+            $table->decimal('withholding', 18, 8)->nullable();
             $table->longText('remark')->nullable();
             $table->string('attachment')->nullable();
             $table->enum('payment_method',['credit','cash']);

--- a/database/migrations/2022_03_13_092650_create_purchase_orders_table.php
+++ b/database/migrations/2022_03_13_092650_create_purchase_orders_table.php
@@ -17,9 +17,9 @@ class CreatePurchaseOrdersTable extends Migration
             $table->id();
             $table->unsignedBigInteger('payment_reference_id');
             $table->date('due_date');
-            $table->float('sub_total');
-            $table->float('tax')->nullable();
-            $table->float('grand_total');
+            $table->decimal('sub_total', 18, 8);
+            $table->decimal('tax', 18, 8)->nullable();
+            $table->decimal('grand_total', 18, 8);
             $table->timestamps();
             $table->foreign('payment_reference_id')->references('id')->on('payment_references'); 
         });

--- a/database/migrations/2022_03_13_104755_create_vat_payments_table.php
+++ b/database/migrations/2022_03_13_104755_create_vat_payments_table.php
@@ -19,10 +19,10 @@ class CreateVatPaymentsTable extends Migration
             $table->unsignedBigInteger('accounting_period_id')->nullable();
             $table->unsignedBigInteger('chart_of_account_id')->nullable();
             $table->string('type');
-            $table->float('previous_period_vat_receivable')->nullable();
-            $table->float('current_period_vat_receivable')->nullable();
-            $table->float('current_period_vat_payment')->nullable();
-            $table->float('current_receivable')->nullable();
+            $table->decimal('previous_period_vat_receivable', 18, 8)->nullable();
+            $table->decimal('current_period_vat_receivable', 18, 8)->nullable();
+            $table->decimal('current_period_vat_payment', 18, 8)->nullable();
+            $table->decimal('current_receivable', 18, 8)->nullable();
             $table->foreign('payment_reference_id')->references('id')->on('payment_references'); 
             $table->foreign('accounting_period_id')->nullable()->references('id')->on('accounting_periods'); 
             $table->foreign('chart_of_account_id')->nullable()->references('id')->on('chart_of_accounts'); 

--- a/database/migrations/2022_03_13_110624_create_withholding_payments_table.php
+++ b/database/migrations/2022_03_13_110624_create_withholding_payments_table.php
@@ -19,7 +19,7 @@ class CreateWithholdingPaymentsTable extends Migration
             $table->unsignedBigInteger('payment_reference_id');
             $table->unsignedBigInteger('accounting_period_id')->nullable();
             $table->unsignedBigInteger('chart_of_account_id')->nullable();
-            $table->float('amount_paid');
+            $table->decimal('amount_paid', 18, 8);
             $table->timestamps();
             $table->foreign('payment_reference_id')->nullable()->references('id')->on('payment_references');
             $table->foreign('accounting_period_id')->nullable()->references('id')->on('accounting_periods');

--- a/database/migrations/2022_03_13_111155_create_bill_payments_table.php
+++ b/database/migrations/2022_03_13_111155_create_bill_payments_table.php
@@ -18,8 +18,8 @@ class CreateBillPaymentsTable extends Migration
             $table->unsignedBigInteger('payment_reference_id');
             $table->unsignedBigInteger('chart_of_account_id')->nullable();
             $table->string('cheque_number')->nullable();
-            $table->float('amount_paid');
             $table->float('discount_account_number')->nullable();
+            $table->decimal('amount_paid');
             $table->timestamps();
             $table->foreign('payment_reference_id')->references('id')->on('payment_references');
             $table->foreign('chart_of_account_id')->nullable()->references('id')->on('chart_of_accounts');

--- a/database/migrations/2022_03_13_111442_create_payroll_payments_table.php
+++ b/database/migrations/2022_03_13_111442_create_payroll_payments_table.php
@@ -17,7 +17,7 @@ class CreatePayrollPaymentsTable extends Migration
             $table->id();
             $table->foreign('payment_reference_id')->references('id')->on('payment_references');  
             $table->date('date');
-            $table->float('total_paid');
+            $table->decimal('total_paid', 18, 8);
             $table->unsignedBigInteger('payment_reference_id');
             $table->timestamps();
         });

--- a/database/migrations/2022_03_13_150841_create_bills_table.php
+++ b/database/migrations/2022_03_13_150841_create_bills_table.php
@@ -20,18 +20,18 @@ class CreateBillsTable extends Migration
             $table->unsignedBigInteger('withholding_payment_id')->nullable();
             $table->date('due_date');
             $table->unsignedBigInteger('chart_of_account_id')->nullable();
-            $table->float('sub_total');
-            $table->float('discount')->nullable();
-            $table->float('tax')->nullable();
-            $table->float('grand_total');
-            $table->float('withholding')->nullable();
+            $table->decimal('sub_total', 18, 8);
+            $table->decimal('discount', 18, 8)->nullable();
+            $table->decimal('tax', 18, 8)->nullable();
+            $table->decimal('grand_total', 18, 8);
+            $table->decimal('withholding', 18, 8)->nullable();
             $table->enum('withholding_status', [
                 'paid',
                 'unpaid',
                 'partially_paid',
             ]);
             $table->string('payment_method');            
-            $table->float('amount_received');        
+            $table->decimal('amount_received', 18, 8);        
             $table->timestamps();    
             $table->foreign('payment_reference_id')->references('id')->on('payment_references');         
             $table->foreign('chart_of_account_id')->nullable()->references('id')->on('chart_of_accounts');

--- a/database/migrations/2022_04_10_121316_create_bill_items_table.php
+++ b/database/migrations/2022_04_10_121316_create_bill_items_table.php
@@ -18,8 +18,8 @@ class CreateBillItemsTable extends Migration
             $table->unsignedBigInteger('inventory_id');
             $table->unsignedBigInteger('payment_reference_id'); 
             $table->integer('quantity'); 
-            $table->float('price')->nullable();
-            $table->float('total_price')->nullable();
+            $table->decimal('price', 18, 8)->nullable();
+            $table->decimal('total_price', 18, 8)->nullable();
             
             $table->timestamps();
             $table->foreign('inventory_id')->references('id')->on('inventories');

--- a/database/migrations/2022_04_12_070924_create_payrolls_table.php
+++ b/database/migrations/2022_04_12_070924_create_payrolls_table.php
@@ -20,15 +20,15 @@ class CreatePayrollsTable extends Migration
             $table->unsignedBigInteger('accounting_system_id')->constrained();
             $table->enum('status', ['pending', 'partially_paid','paid', 'cancelled'])->default('pending');
             $table->string('paid_by')->nullable();
-            $table->float('total_salary', 10, 2)->default(0);
-            $table->float('total_addition', 10, 2)->default(0);
-            $table->float('total_deduction', 10, 2)->default(0);
-            $table->float('total_overtime', 10, 2)->default(0);
-            $table->float('total_loan', 10, 2)->default(0);
-            $table->float('total_tax', 10, 2)->default(0);
-            $table->float('total_pension_7', 10, 2)->default(0);
-            $table->float('total_pension_11', 10, 2)->default(0);
-            $table->float('net_pay', 10, 2)->default(0);
+            $table->decimal('total_salary', 18, 8)->default(0);
+            $table->decimal('total_addition', 18, 8)->default(0);
+            $table->decimal('total_deduction', 18, 8)->default(0);
+            $table->decimal('total_overtime', 18, 8)->default(0);
+            $table->decimal('total_loan', 18, 8)->default(0);
+            $table->decimal('total_tax', 18, 8)->default(0);
+            $table->decimal('total_pension_7', 18, 8)->default(0);
+            $table->decimal('total_pension_11', 18, 8)->default(0);
+            $table->decimal('net_pay', 18, 8)->default(0);
             $table->foreign('employee_id')->references('id')->on('employees');
 
             $table->timestamps();

--- a/database/migrations/2022_04_12_071034_create_overtimes_table.php
+++ b/database/migrations/2022_04_12_071034_create_overtimes_table.php
@@ -22,7 +22,7 @@ class CreateOvertimesTable extends Migration
             $table->enum('is_weekend_holiday', ['yes', 'no'])->nullable();
             $table->time('from');
             $table->time('to');
-            $table->float('price', 10, 2)->default(0);
+            $table->decimal('price', 18, 8)->default(0);
             $table->string('description')->nullable();
             $table->string('type')->default('overtime');
             $table->enum('status',['pending','paid','cancelled'])->default('pending');

--- a/database/migrations/2022_04_12_071101_create_additions_table.php
+++ b/database/migrations/2022_04_12_071101_create_additions_table.php
@@ -19,7 +19,7 @@ class CreateAdditionsTable extends Migration
             $table->unsignedBigInteger('employee_id');
             $table->unsignedBigInteger('payroll_id')->nullable();
             $table->date('date');  
-            $table->float('price', 10, 2)->default(0);
+            $table->decimal('price', 18, 8)->default(0);
             $table->string('description')->nullable();
             $table->string('type')->default('addition');
             $table->enum('status',['pending','paid','cancelled'])->default('pending');

--- a/database/migrations/2022_04_12_071122_create_deductions_table.php
+++ b/database/migrations/2022_04_12_071122_create_deductions_table.php
@@ -19,7 +19,7 @@ class CreateDeductionsTable extends Migration
             $table->unsignedBigInteger('employee_id');
             $table->unsignedBigInteger('payroll_id')->nullable();
             $table->date('date');
-            $table->float('price', 10, 2)->default(0);
+            $table->decimal('price', 18, 8)->default(0);
             $table->string('description')->nullable();
             $table->string('type')->default('deduction');
             $table->enum('status',['pending','paid','cancelled'])->default('pending');

--- a/database/migrations/2022_04_12_071202_create_loans_table.php
+++ b/database/migrations/2022_04_12_071202_create_loans_table.php
@@ -19,7 +19,7 @@ class CreateLoansTable extends Migration
             $table->unsignedBigInteger('employee_id');
             $table->unsignedBigInteger('payroll_id')->nullable();
             $table->date('date');
-            $table->float('loan')->default(0);
+            $table->decimal('loan', 18, 8)->default(0);
             $table->string('paid_in');
             $table->string('description')->nullable();
             $table->string('type')->default('loan');

--- a/database/migrations/2022_04_19_011649_create_overtime_payroll_rules_table.php
+++ b/database/migrations/2022_04_19_011649_create_overtime_payroll_rules_table.php
@@ -18,9 +18,9 @@ class CreateOvertimePayrollRulesTable extends Migration
             $table->foreignId('accounting_system_id')->constrained();
             $table->integer('working_days');
             $table->integer('working_hours');
-            $table->float('day_rate');
-            $table->float('night_rate');
-            $table->float('holiday_weekend_rate');
+            $table->decimal('day_rate', 5, 2);
+            $table->decimal('night_rate', 5, 2);
+            $table->decimal('holiday_weekend_rate', 5, 2);
             $table->timestamps();
         });
     }

--- a/database/migrations/2022_04_19_012228_create_income_tax_payroll_rules_table.php
+++ b/database/migrations/2022_04_19_012228_create_income_tax_payroll_rules_table.php
@@ -16,9 +16,9 @@ class CreateIncomeTaxPayrollRulesTable extends Migration
         Schema::create('income_tax_payroll_rules', function (Blueprint $table) {
             $table->id();
             $table->foreignId('accounting_system_id')->constrained();
-            $table->float('income');
-            $table->float('rate');
-            $table->float('deduction');
+            $table->decimal('income', 18, 8);
+            $table->decimal('rate', 18, 8);
+            $table->decimal('deduction', 18, 8);
             $table->timestamps();
         });
     }

--- a/database/migrations/2022_04_20_044703_create_pension_payments_table.php
+++ b/database/migrations/2022_04_20_044703_create_pension_payments_table.php
@@ -19,7 +19,7 @@ class CreatePensionPaymentsTable extends Migration
             $table->unsignedBigInteger('accounting_period_id')->nullable();
             $table->unsignedBigInteger('chart_of_account_id')->nullable();
             $table->unsignedBigInteger('cheque_number')->nullable();
-            $table->float('amount_received');
+            $table->decimal('amount_received', 18, 8);
             $table->timestamps();
             $table->foreign('payment_reference_id')->references('id')->on('payment_references');
             $table->foreign('accounting_period_id')->references('id')->on('accounting_periods');

--- a/database/migrations/2022_04_20_045356_create_income_tax_payments_table.php
+++ b/database/migrations/2022_04_20_045356_create_income_tax_payments_table.php
@@ -19,7 +19,7 @@ class CreateIncomeTaxPaymentsTable extends Migration
             $table->unsignedBigInteger('accounting_period_id')->nullable();
             $table->unsignedBigInteger('chart_of_account_id')->nullable();
             $table->unsignedBigInteger('cheque_number')->nullable();
-            $table->float('amount_received');
+            $table->decimal('amount_received', 18, 8);
             $table->timestamps();
             $table->foreign('payment_reference_id')->references('id')->on('payment_references');
             $table->foreign('accounting_period_id')->references('id')->on('accounting_periods');

--- a/database/migrations/2022_06_02_070300_create_deposits_table.php
+++ b/database/migrations/2022_06_02_070300_create_deposits_table.php
@@ -19,7 +19,7 @@ class CreateDepositsTable extends Migration
             $table->unsignedBigInteger('chart_of_account_id');
             $table->enum('status',['Deposited','Void'])->default('Deposited');
             $table->date('deposit_ticket_date');
-            $table->double('total_amount',8,2)->nullable();
+            $table->decimal('total_amount', 18, 8)->nullable();
             $table->string('remark')->nullable();
             $table->timestamps();
             $table->string('reference_number')->nullable();

--- a/database/migrations/2022_06_02_070301_create_transactions_table.php
+++ b/database/migrations/2022_06_02_070301_create_transactions_table.php
@@ -19,7 +19,7 @@ class CreateTransactionsTable extends Migration
             $table->unsignedBigInteger('chart_of_account_id');
             $table->string('type');
             $table->string('description')->nullable();
-            $table->float('amount');
+            $table->decimal('amount', 18, 8);
             $table->timestamps();
 
             $table->foreign('chart_of_account_id')->references('id')->on('chart_of_accounts');

--- a/database/migrations/2022_06_02_153458_create_transfers_table.php
+++ b/database/migrations/2022_06_02_153458_create_transfers_table.php
@@ -18,7 +18,7 @@ class CreateTransfersTable extends Migration
             $table->foreignId('accounting_system_id')->constrained();
             $table->unsignedBigInteger('from_account_id');
             $table->unsignedBigInteger('to_account_id');
-            $table->decimal('amount', 10, 2)->nullable();
+            $table->decimal('amount', 18, 8)->nullable();
             $table->string('reason')->nullable();
             $table->enum('status', ['completed', 'void'])->default('completed');
             $table->foreignId('journal_entry_id')->nullable()->constrained();

--- a/database/migrations/2022_08_06_094831_create_pensions_table.php
+++ b/database/migrations/2022_08_06_094831_create_pensions_table.php
@@ -18,8 +18,8 @@ class CreatePensionsTable extends Migration
             $table->foreignId('accounting_system_id')->constrained();
             $table->unsignedBigInteger('employee_id');
             $table->unsignedBigInteger('payroll_id')->nullable();
-            $table->float('pension_07_amount', 10,2)->default(0);
-            $table->float('pension_11_amount',10,2)->default(0);
+            $table->decimal('pension_07_amount', 18, 6)->default(0);
+            $table->decimal('pension_11_amount', 18, 6)->default(0);
             $table->string('type')->default('pension');
             $table->enum('status',['pending','paid','cancelled'])->default('pending');
             $table->foreign('payroll_id')->references('id')->on('payrolls');

--- a/database/migrations/2022_08_06_095632_create_tax_payrolls_table.php
+++ b/database/migrations/2022_08_06_095632_create_tax_payrolls_table.php
@@ -18,10 +18,10 @@ class CreateTaxPayrollsTable extends Migration
             $table->foreignId('accounting_system_id')->constrained();
             $table->unsignedBigInteger('employee_id');
             $table->unsignedBigInteger('payroll_id')->nullable();
-            $table->decimal('taxable_income', 10, 2)->default(0);
-            $table->decimal('tax_rate', 10, 2)->default(0);
-            $table->decimal('tax_deduction', 10, 2)->default(0);
-            $table->decimal('tax_amount', 10, 2)->default(0);
+            $table->decimal('taxable_income', 18, 6)->default(0);
+            $table->decimal('tax_rate', 18, 6)->default(0);
+            $table->decimal('tax_deduction', 18, 6)->default(0);
+            $table->decimal('tax_amount', 18, 6)->default(0);
             $table->string('type')->default('tax');
             $table->enum('status',['pending','paid','cancelled'])->default('pending');
             $table->foreign('payroll_id')->references('id')->on('payrolls');

--- a/database/migrations/2022_08_06_095651_create_basic_salaries_table.php
+++ b/database/migrations/2022_08_06_095651_create_basic_salaries_table.php
@@ -18,7 +18,7 @@ class CreateBasicSalariesTable extends Migration
             $table->foreignId('accounting_system_id')->constrained();
             $table->unsignedBigInteger('employee_id');
             $table->unsignedBigInteger('payroll_id')->nullable();
-            $table->float('price', 10,2)->default(0);
+            $table->decimal('price', 18, 2)->default(0);
             $table->string('type')->default('basic salary');
             $table->enum('status',['pending','paid','cancelled'])->default('pending');
             $table->foreign('payroll_id')->references('id')->on('payrolls');  


### PR DESCRIPTION
This is due to an issue related to using `float` datatype being prone to errors. Closes #213 .