### PR TITLE
Rework Payroll Generation

### DIFF
--- a/app/Http/Controllers/PayrollController.php
+++ b/app/Http/Controllers/PayrollController.php
@@ -58,6 +58,7 @@ class PayrollController extends Controller
                 $join->on('p.id', '=', 'payroll_periods.id');
             })
             ->where('accounting_periods.accounting_system_id', session('accounting_system_id'))
+            ->orderBy('accounting_periods.period_number', 'asc')
             ->get();
 
         // return $payroll_periods;

--- a/app/Http/Controllers/PayrollController.php
+++ b/app/Http/Controllers/PayrollController.php
@@ -18,7 +18,6 @@ use App\Models\Settings\PayrollRules\IncomeTaxPayrollRules;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use DB;
 
 class PayrollController extends Controller
 {
@@ -249,37 +248,72 @@ class PayrollController extends Controller
      * @param  \App\Models\Payroll  $payroll
      * @return \Illuminate\Http\Response
      */
-    public function show($id)
+    public function show(PayrollPeriod $payroll_period)
     {
+        if($payroll_period->accounting_system_id != session('accounting_system_id'))
+            abort(404);
+
+        $payroll_period->period;
+
+        $payrolls = DB::table('payrolls')
+            ->select(
+                'employees.id as employee_id',
+                'employees.first_name',
+                'employees.father_name',
+                'employees.grandfather_name',
+                'payrolls.total_salary',
+                'payrolls.total_addition',
+                'payrolls.total_deduction',
+                'payrolls.total_overtime',
+                'payrolls.total_loan',
+                'payrolls.total_tax',
+                'payrolls.total_pension_7',
+                'payrolls.total_pension_11',
+                'payrolls.net_pay',
+            )
+            ->leftJoin('employees', 'employees.id', 'payrolls.employee_id')
+            ->where('payrolls.payroll_period_id', $payroll_period->id)
+            ->where('payrolls.accounting_system_id', session('accounting_system_id'))
+            ->get();
+
+        // return [
+        //     'payroll_period' => $payroll_period,
+        //     'payrolls' => $payrolls,
+        // ];
+        
+        // TODO: Show breakdown by user (in a separate page)
         // get all related basic salary, additions, deductions, overtimes, loans, pensions, tax related to payroll
-        $payroll_items = DB::table('basic_salaries')
-        ->select('id','employee_id','payroll_id','price as amount','type')
-        ->where('payroll_id',$id)
-        ->union(DB::table('additions')
-        ->select('id','employee_id','payroll_id','price as amount','type')
-        ->where('payroll_id',$id))
-        ->union(DB::table('deductions')
-        ->select('id','employee_id','payroll_id','price as amount','type')
-        ->where('payroll_id',$id))
-        ->union(DB::table('overtimes')
-        ->select('id','employee_id','payroll_id','price as amount','type')
-        ->where('payroll_id',$id))
-        ->union(DB::table('loans')
-        ->select('id','employee_id','payroll_id','loan as amount','type')
-        ->where('payroll_id',$id))
-        ->union(DB::table('pensions')
-        ->select('id','employee_id','payroll_id','pension_07_amount as amount','type')
-        ->where('payroll_id',$id))
-        ->union(DB::table('pensions')
-        ->select('id','employee_id','payroll_id','pension_11_amount as amount','type')
-        ->where('payroll_id',$id))
-        ->union(DB::table('tax_payrolls')
-        ->select('id','employee_id','payroll_id','tax_amount as amount','type')
-        ->where('payroll_id',$id))
-        ->get();
+        // $payroll_items = DB::table('basic_salaries')
+        // ->select('id','employee_id','payroll_id','price as amount','type')
+        // ->where('payroll_id',$id)
+        // ->union(DB::table('additions')
+        // ->select('id','employee_id','payroll_id','price as amount','type')
+        // ->where('payroll_id',$id))
+        // ->union(DB::table('deductions')
+        // ->select('id','employee_id','payroll_id','price as amount','type')
+        // ->where('payroll_id',$id))
+        // ->union(DB::table('overtimes')
+        // ->select('id','employee_id','payroll_id','price as amount','type')
+        // ->where('payroll_id',$id))
+        // ->union(DB::table('loans')
+        // ->select('id','employee_id','payroll_id','loan as amount','type')
+        // ->where('payroll_id',$id))
+        // ->union(DB::table('pensions')
+        // ->select('id','employee_id','payroll_id','pension_07_amount as amount','type')
+        // ->where('payroll_id',$id))
+        // ->union(DB::table('pensions')
+        // ->select('id','employee_id','payroll_id','pension_11_amount as amount','type')
+        // ->where('payroll_id',$id))
+        // ->union(DB::table('tax_payrolls')
+        // ->select('id','employee_id','payroll_id','tax_amount as amount','type')
+        // ->where('payroll_id',$id))
+        // ->get();
 
 
-        return view('hr.payroll.show',compact('payroll_items','id'));
+        return view('hr.payroll.show', compact(
+            'payroll_period',
+            'payrolls',
+        ));
     }
 
     /**

--- a/app/Http/Controllers/PayrollController.php
+++ b/app/Http/Controllers/PayrollController.php
@@ -236,7 +236,9 @@ class PayrollController extends Controller
                     }
                 }
                 // Net Pay
-                $net_pay = $total_salary + $total_addition + $total_overtime - $total_pension_7 - $total_pension_11 - $total_deduction - $total_loan - $tax_amount;
+                // ? total_pension_11 was removed as per #190
+                // $net_pay = $total_salary + $total_addition + $total_overtime - $total_pension_7 - $total_pension_11 - $total_deduction - $total_loan - $tax_amount;
+                $net_pay = $total_salary + $total_addition + $total_overtime - $total_pension_7 - $total_deduction - $total_loan - $tax_amount;
                 $payroll->net_pay = $net_pay;
                 $payroll->save();
         }

--- a/app/Http/Controllers/PayrollController.php
+++ b/app/Http/Controllers/PayrollController.php
@@ -345,27 +345,28 @@ class PayrollController extends Controller
      * @param  \App\Models\Payroll  $payroll
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id)
+    public function destroy(PayrollPeriod $payroll_period)
     {
-        $payroll = Payroll::find($id);
-        if($payroll->status == 'paid')
-        {
-            return redirect()->route('payrolls.payrolls.index')->with('error','Error Deleting Payroll. Payroll Already Paid');
+        $payroll_period->payrolls;
+
+        if($payroll_period->is_paid) {
+            return redirect()->route('payrolls.index')->with('error','Error Deleting Payroll. Payroll Already Paid');
         }
-        else
+
+        foreach($payroll_period->payrolls as $payroll)
         {
-            // change all related records payroll_id to null
-            $basic_salaries = BasicSalary::where('payroll_id',$id)->delete();
-            $addition = Addition::where('payroll_id',$id)->update(['payroll_id'=>null]);
-            $deduction = Deduction::where('payroll_id',$id)->update(['payroll_id'=>null]);
-            $overtime = Overtime::where('payroll_id',$id)->update(['payroll_id'=>null]);
-            $loan = Loan::where('payroll_id',$id)->update(['payroll_id'=>null]);
-            $pension = Pension::where('payroll_id',$id)->delete();
-            $tax = TaxPayroll::where('payroll_id',$id)->delete();            
+            BasicSalary::where('payroll_id',$payroll->id)->delete();
+            Addition::where('payroll_id',$payroll->id)->update(['payroll_id'=>null]);
+            Deduction::where('payroll_id',$payroll->id)->update(['payroll_id'=>null]);
+            Overtime::where('payroll_id',$payroll->id)->update(['payroll_id'=>null]);
+            Loan::where('payroll_id',$payroll->id)->update(['payroll_id'=>null]);
+            Pension::where('payroll_id',$payroll->id)->delete();
+            TaxPayroll::where('payroll_id',$payroll->id)->delete();
             $payroll->delete();
-            $payroll_period = PayrollPeriod::where('id', $payroll->payroll_period_id)->delete();
-           
-            return redirect()->route('payrolls.payrolls.index')->with('success','Payroll Deleted Successfully');
-        }       
+        }
+
+        $payroll_period->delete();   
+
+        return redirect()->route('payrolls.index')->with('success','Payroll Deleted Successfully');
     }
 }

--- a/app/Http/Controllers/PayrollController.php
+++ b/app/Http/Controllers/PayrollController.php
@@ -239,7 +239,7 @@ class PayrollController extends Controller
                 $payroll->save();
         }
         }
-        return redirect()->route('payrolls.payrolls.index')->with('success','Payroll Created Successfully');
+        return redirect()->route('payrolls.index')->with('success','Payroll Created Successfully');
     }
 
     /**

--- a/app/Http/Controllers/PayrollController.php
+++ b/app/Http/Controllers/PayrollController.php
@@ -103,6 +103,12 @@ class PayrollController extends Controller
             if($employees->isEmpty())
                 return redirect()->route('payrolls.payrolls.index')->with('error','No records to create Payroll');
 
+            // Create Payroll Period
+            $payroll_period = new PayrollPeriod;
+            $payroll_period->period_id = $accounting_period->id;
+            $payroll_period->accounting_system_id = $accounting_system_id;
+            $payroll_period->save();
+
             foreach($employees as $employee){
                 $additions = Addition::where('accounting_system_id',$accounting_system->id)->where('employee_id',$employee->id)
                 ->whereBetween('date', [$accounting_period->date_from, $accounting_period->date_to])
@@ -117,11 +123,7 @@ class PayrollController extends Controller
                 ->whereBetween('date', [$accounting_period->date_from, $accounting_period->date_to])
                 ->get();            
                 
-                // Create Payroll Period
-                $payroll_period = new PayrollPeriod;
-                $payroll_period->period_id = $accounting_period->id;
-                $payroll_period->accounting_system_id = $accounting_system_id;
-                $payroll_period->save();
+                
                 // Create Payroll
                 $payroll = new Payroll;
                 $payroll->payroll_period_id = $payroll_period->id;

--- a/app/Models/PayrollPeriod.php
+++ b/app/Models/PayrollPeriod.php
@@ -25,5 +25,10 @@ class PayrollPeriod extends Model
         return $this->hasOne(Payroll::class, 'payroll_period_id','id');
     }
 
+    public function payrolls()
+    {
+        return $this->hasMany(Payroll::class, 'payroll_period_id','id');
+    }
+
 
 }

--- a/database/migrations/2022_07_24_133731_create_payroll_periods_table.php
+++ b/database/migrations/2022_07_24_133731_create_payroll_periods_table.php
@@ -16,6 +16,7 @@ class CreatePayrollPeriodsTable extends Migration
         Schema::create('payroll_periods', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('period_id')->constrained('accounting_periods');
+            $table->boolean('is_paid')->default(false);
             $table->unsignedBigInteger('accounting_system_id')->constrained();
             $table->timestamps();
         });

--- a/resources/views/hr/payroll/index.blade.php
+++ b/resources/views/hr/payroll/index.blade.php
@@ -182,11 +182,11 @@
                                     <i class='fa fa-eye'></i>
                                 </span>
                             </a>
-                            <button type="button" class="btn btn-small btn-icon btn-danger" @if(!$period->payroll_period_id || !$period->is_paid) disabled @else disabled @endif>
+                            {{-- <button type="button" class="btn btn-small btn-icon btn-danger" @if(!$period->payroll_period_id || $period->is_paid) disabled @endif>
                                 <span class="icon text-white-50">
                                     <i class='fa fa-trash'></i>
                                 </span>
-                            </button>
+                            </button> --}}
                         </td>
 
                     </tr>

--- a/resources/views/hr/payroll/index.blade.php
+++ b/resources/views/hr/payroll/index.blade.php
@@ -111,6 +111,11 @@
             <table class="table table-bordered" id="dataTables" width="100%" cellspacing="0">
                 <thead>
                     <th>Period</th>
+                    <th>Date From</th>
+                    <th>Date To</th>
+                    <th>Number of Employees</th>
+                    <th>Status</th>
+                    {{-- <th>Period</th>
                     <th>Employee Name</th>
                     <th>Status</th>
                     <th>Basic Salary</th>
@@ -121,14 +126,34 @@
                     <th>Tax</th>
                     <th>Pension 7%</th>
                     <th>Pension 11%</th>
-                    <th>Net Pay</th>
+                    <th>Net Pay</th> --}}
                     <th id="thead-actions">Actions</th>    
                 </thead>
                 <tbody>
-                    @foreach($payrolls as $payroll)
+                    @foreach($payroll_periods as $period)
 
                     <tr>
-                        <td class="table-item-content">{{$payroll->payrollPeriod->period->period_number}}</td>
+                        <td>
+                            # 
+                            @if($period->period_number < 10) 
+                                {{ '0' . $period->period_number }} 
+                            @else
+                                {{ $period->period_number }}
+                            @endif
+                        </td>
+                        <td>{{ $period->date_from }}</td>
+                        <td>{{ $period->date_to }}</td>
+                        <td>{{ $period->employee_count }}</td>
+                        <td>
+                            @if(!$period->payroll_period_id)
+                                <span class="badge badge-secondary">Ungenerated</span>
+                            @elseif(!$period->is_paid)
+                                <span class="badge badge-warning">Unpaid</span>
+                            @else
+                                <span class="badge badge-success">Paid</span>
+                            @endif
+                        </td>
+                        {{-- <td class="table-item-content">{{$payroll->payrollPeriod->period->period_number}}</td>
                         <td class="table-item-content">{{$payroll->employee->first_name}}</td>
                         <td class="table-item-content"><span class="badge badge-secondary">{{$payroll->status}}</span></td>
                         <td class="table-item-content">{{$payroll->total_salary}} Birr</td>
@@ -139,14 +164,25 @@
                         <td class="table-item-content">{{$payroll->total_tax}} Birr</td>
                         <td class="table-item-content">{{$payroll->total_pension_7}} Birr</td>
                         <td class="table-item-content">{{$payroll->total_pension_11}} Birr</td>
-                        <td class="table-item-content">{{$payroll->net_pay}} Birr</td>
+                        <td class="table-item-content">{{$payroll->net_pay}} Birr</td> --}}
                         <td>
-                            <a href="{{ route('payrolls.payrolls.show', $payroll->id) }}" role="button" class="btn btn-small btn-icon btn-primary" data-toggle="tooltip" data-placement="bottom" title="View">
+                            {{-- <a href="{{ route('payrolls.payrolls.show', $payroll->id) }}" role="button" class="btn btn-small btn-icon btn-primary" data-toggle="tooltip" data-placement="bottom" title="View">
+                                <span class="icon text-white-50">
+                                    <i class='fa fa-eye'></i>
+                                </span>
+                            </a> --}}
+                            <a href="
+                                @if(!$period->payroll_period_id)
+                                    {{ 'javascript:void(0)' }}
+                                @else
+                                    {{ '/hr/payrolls/' . $period->payroll_period_id }}
+                                @endif
+                                " role="button" class="btn btn-small btn-icon btn-primary @if(!$period->payroll_period_id) disabled @endif" data-toggle="tooltip" data-placement="bottom" title="View">
                                 <span class="icon text-white-50">
                                     <i class='fa fa-eye'></i>
                                 </span>
                             </a>
-                            <button type="button" class="btn btn-small btn-icon btn-danger" disabled>
+                            <button type="button" class="btn btn-small btn-icon btn-danger" @if(!$period->payroll_period_id || !$period->is_paid) disabled @else disabled @endif>
                                 <span class="icon text-white-50">
                                     <i class='fa fa-trash'></i>
                                 </span>
@@ -172,7 +208,7 @@
                 </button>
             </div>
             <div class="modal-body">
-                <form action="{{route('payrolls.payrolls.store')}}" method="post">
+                <form action="{{ url('/hr/payrolls/') }}" method="post">
                     @csrf
                     {{-- <div class="form-group row">
                         <label for="employee" class="col-12 col-md-3">Employee</label>
@@ -189,7 +225,15 @@
                         <div class="col-12 col-lg-8">
                             <select class="form-control" id="period" name="period">
                                 @foreach($accounting_periods_with_no_payroll as $period)
-                                    <option value="{{$period->id}}">{{$period->period_number}}</option>
+                                    <option value="{{$period->id}}">
+                                        # 
+                                        @if($period->period_number < 10) 
+                                            {{ '0' . $period->period_number }} 
+                                        @else
+                                            {{ $period->period_number }}
+                                        @endif
+                                        | 
+                                        {{ $period->date_from }} to {{ $period->date_to }}</option>
                                 @endforeach
                             </select>
                         </div>
@@ -280,9 +324,9 @@
 
 
 <script>
-    $(document).ready(function () {
-    $('#dataTables').DataTable();
-    $('.dataTables_filter').addClass('pull-right');
-    });
+    // $(document).ready(function () {
+    // $('#dataTables').DataTable();
+    // $('.dataTables_filter').addClass('pull-right');
+    // });
 </script>
 @endsection

--- a/resources/views/hr/payroll/show-employee.blade.php
+++ b/resources/views/hr/payroll/show-employee.blade.php
@@ -1,0 +1,109 @@
+@extends('template.index')
+
+@push('styles')
+<style>
+    .table-item-content { 
+        /** Equivalent to pt-3 */
+        padding-top:1rem!important;
+    }
+
+    #thead-actions {
+        /** Fixed width, increase if adding addt. buttons **/
+        width:120px;
+    }
+</style>
+@endpush
+
+
+@section('content')
+
+{{-- Button Group Navigation --}}
+{{-- <div class="btn-group mb-3" role="group" aria-label="Button group with nested dropdown">
+    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#modal-select-period">
+        <span class="icon text-white-50">
+            <i class="fas fa-pen"></i>
+        </span>
+        <span class="text">New</span>
+    </button>   
+</div> --}}
+
+<a href="{{ route('payrolls.payrolls.index') }}" class="btn btn-primary mb-3">
+    <span class="icon text-white-50">
+        <i class="fas fa-arrow-left"></i>
+    </span>
+    <span class="text">Back</span>
+</a>
+
+<button type="button" class="btn btn-danger btn-icon mb-3" data-toggle="modal" data-target="#DeleteModal">
+    <span class="icon text-white-50">
+        <i class="fas fa-trash"></i>
+    </span>
+    <span class="text">Delete Payroll</span>
+  </button>
+
+{{-- Page Content --}}
+<div class="card">
+    {{-- alert messge --}}
+    @if (session('success'))
+        <div class="alert alert-success">
+            {{ session('success') }}
+        </div>
+    @elseif (session('error'))
+        <div class="alert alert-danger">
+            {{ session('error') }}
+        </div>
+    @endif
+    <div class="card-body">
+        <div class="table-responsive">
+            <table class="table table-bordered" width="100%" cellspacing="0">
+                <thead>
+                    <th>#</th>
+                    <th>Source</th>
+                    <th>Amount</th>              
+                </thead>
+                <tbody>
+                    @foreach($payroll_items as $payroll)
+                    <tr>
+                        <td>{{ $loop->iteration }}</td>
+                        <td>{{ $payroll->type }}</td>
+                        <td>{{ $payroll->amount }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+{{-- Delete Modal --}}
+<div class="modal fade" id="DeleteModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="exampleModalLabel">Delete Payroll</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                Are you sure you want to delete this payroll?
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                <form action="{{ route('payrolls.payrolls.destroy', $id) }}" method="POST">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-danger">Delete</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    $(document).ready(function () {
+    $('#dataTables').DataTable();
+    $('.dataTables_filter').addClass('pull-right');
+    });
+</script>
+@endsection

--- a/resources/views/hr/payroll/show.blade.php
+++ b/resources/views/hr/payroll/show.blade.php
@@ -35,7 +35,7 @@
 </a>
 
 <button type="button" class="btn btn-danger btn-icon mb-3" data-toggle="modal" data-target="#DeleteModal"
-    @if(!$payroll_period->is_paid) disabled @else disabled @endif>
+    @if($payroll_period->is_paid) disabled @endif>
     <span class="icon text-white-50">
         <i class="fas fa-trash"></i>
     </span>
@@ -134,15 +134,22 @@
                 </button>
             </div>
             <div class="modal-body">
-                Are you sure you want to delete this payroll?
+                @if(!$payroll_period->period->is_paid)
+                    Are you sure you want to delete this payroll?
+                @else
+                    This payroll has already been paid. No further action is required.
+                @endif 
+                
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                {{-- <form action="{{ route('payrolls.payrolls.destroy', $id) }}" method="POST">
-                    @csrf
-                    @method('DELETE')
-                    <button type="submit" class="btn btn-danger">Delete</button>
-                </form> --}}
+                @if(!$payroll_period->period->is_paid)
+                    <form action="{{ route('payrolls.destroy', $payroll_period->id) }}" method="POST">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-danger">Delete</button>
+                    </form>
+                @endif
             </div>
         </div>
     </div>

--- a/resources/views/hr/payroll/show.blade.php
+++ b/resources/views/hr/payroll/show.blade.php
@@ -27,19 +27,20 @@
     </button>   
 </div> --}}
 
-<a href="{{ route('payrolls.payrolls.index') }}" class="btn btn-primary mb-3">
+<a href="{{ url('/hr/payrolls') }}" class="btn btn-primary mb-3">
     <span class="icon text-white-50">
         <i class="fas fa-arrow-left"></i>
     </span>
     <span class="text">Back</span>
 </a>
 
-<button type="button" class="btn btn-danger btn-icon mb-3" data-toggle="modal" data-target="#DeleteModal">
+<button type="button" class="btn btn-danger btn-icon mb-3" data-toggle="modal" data-target="#DeleteModal"
+    @if(!$payroll_period->is_paid) disabled @else disabled @endif>
     <span class="icon text-white-50">
         <i class="fas fa-trash"></i>
     </span>
     <span class="text">Delete Payroll</span>
-  </button>
+</button>
 
 {{-- Page Content --}}
 <div class="card">
@@ -54,20 +55,67 @@
         </div>
     @endif
     <div class="card-body">
+        <table class="table table-borderless table-sm">
+            <tr>
+                <td style="width:200px">Period Number</td>
+                <td><strong>
+                    @if($payroll_period->period->period_number < 10) 
+                        {{ '0' . $payroll_period->period->period_number }} 
+                    @else
+                        {{ $payroll_period->period->period_number }}
+                    @endif
+                </strong></td>
+            </tr>
+            <tr>
+                <td>Date From</td>
+                <td><strong>{{ $payroll_period->period->date_from }}</strong></td>
+            </tr>
+            <tr>
+                <td>Date To</td>
+                <td><strong>{{ $payroll_period->period->date_to }}</strong></td>
+            </tr>
+            <tr>
+                <td>Status</td>
+                <td>
+                    @if(!$payroll_period->period->is_paid)
+                        <span class="badge badge-warning">Unpaid</span>
+                    @else
+                        <span class="badge badge-success">Paid</span>
+                    @endif    
+                </td>
+            </tr>
+        </table>
+
         <div class="table-responsive">
-            <table class="table table-bordered" width="100%" cellspacing="0">
+            <table class="table table-bordered" id="dataTables" width="100%" cellspacing="0">
                 <thead>
-                    <th>#</th>
-                    <th>Source</th>
-                    <th>Amount</th>              
+                    <th>ID</th>
+                    <th>Employee Name</th>
+                    <th>Basic Salary</th>
+                    <th>Additions</th>
+                    <th>Deductions</th>
+                    <th>Overtime</th>
+                    <th>Loan</th>
+                    <th>Tax</th>
+                    <th>Pension 7%</th>
+                    <th>Pension 11%</th>
+                    <th>Net Pay</th>
                 </thead>
                 <tbody>
-                    @foreach($payroll_items as $payroll)
-                    <tr>
-                        <td>{{ $loop->iteration }}</td>
-                        <td>{{ $payroll->type }}</td>
-                        <td>{{ $payroll->amount }}</td>
-                    </tr>
+                    @foreach($payrolls as $payroll)
+                        <tr>
+                            <td class="table-item-content">{{ $payroll->employee_id }}</td>
+                            <td class="table-item-content">{{ $payroll->first_name }}</td>
+                            <td class="table-item-content text-right">{{ number_format($payroll->total_salary, 2) }}</td>
+                            <td class="table-item-content text-right">{{ number_format($payroll->total_addition, 2) }}</td>
+                            <td class="table-item-content text-right">{{ number_format($payroll->total_deduction, 2) }}</td>
+                            <td class="table-item-content text-right">{{ number_format($payroll->total_overtime, 2) }}</td>
+                            <td class="table-item-content text-right">{{ number_format($payroll->total_loan, 2) }}</td>
+                            <td class="table-item-content text-right">{{ number_format($payroll->total_tax, 2) }}</td>
+                            <td class="table-item-content text-right">{{ number_format($payroll->total_pension_7, 2) }}</td>
+                            <td class="table-item-content text-right">{{ number_format($payroll->total_pension_11, 2) }}</td>
+                            <td class="table-item-content text-right"><strong>{{ number_format($payroll->net_pay, 2) }}</strong></td>
+                        </tr>
                     @endforeach
                 </tbody>
             </table>
@@ -90,11 +138,11 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                <form action="{{ route('payrolls.payrolls.destroy', $id) }}" method="POST">
+                {{-- <form action="{{ route('payrolls.payrolls.destroy', $id) }}" method="POST">
                     @csrf
                     @method('DELETE')
                     <button type="submit" class="btn btn-danger">Delete</button>
-                </form>
+                </form> --}}
             </div>
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -561,7 +561,11 @@ Route::group([
                 'middleware' => 'acctsys.permission:14',
             ], function(){
                 // HTML
-                Route::resource('/hr/payrolls', PayrollController::class);
+                // Route::resource('/hr/payrolls', PayrollController::class);
+
+                Route::get('/hr/payrolls', [PayrollController::class, 'index'])->name('index');
+                Route::post('/hr/payrolls', [PayrollController::class, 'store'])->name('store');
+                
             });
         
             /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -565,6 +565,7 @@ Route::group([
 
                 Route::get('/hr/payrolls', [PayrollController::class, 'index'])->name('index');
                 Route::post('/hr/payrolls', [PayrollController::class, 'store'])->name('store');
+                Route::get('/hr/payrolls/{payroll_period}', [PayrollController::class, 'show'])->name('show');
                 
             });
         

--- a/routes/web.php
+++ b/routes/web.php
@@ -566,6 +566,7 @@ Route::group([
                 Route::get('/hr/payrolls', [PayrollController::class, 'index'])->name('index');
                 Route::post('/hr/payrolls', [PayrollController::class, 'store'])->name('store');
                 Route::get('/hr/payrolls/{payroll_period}', [PayrollController::class, 'show'])->name('show');
+                Route::delete('/hr/payrolls/{payroll_period}', [PayrollController::class, 'destroy'])->name('destroy');
                 
             });
         


### PR DESCRIPTION
This starts by showing accounting periods instead on `payrolls.index` as per feedback from #192. 
![image](https://user-images.githubusercontent.com/32955000/193399377-593f6b9e-d207-45e6-b376-02126a149914.png)

The view's old layout is repurposed as `show` per accounting period. However, it can only be viewed if the payroll is already generated for that period. Moreover, the Net Pay will no longer be deducted by Pension 11% as per feedback from #190 where the employer will pay it in behalf of the employee.
![image](https://user-images.githubusercontent.com/32955000/193399387-2bd2482b-f911-47a5-bfa2-3238ca135208.png)



Closes #190
Closes #192 