### PR TITLE
[Vendor/Payments] Fix column name conflicts in payments table query

### DIFF
--- a/app/Http/Controllers/PaymentsController.php
+++ b/app/Http/Controllers/PaymentsController.php
@@ -65,17 +65,16 @@ class PaymentsController extends Controller
 
                 // Payroll Payments
                 'payroll_payments.total_paid as payroll_amount',
-                'pp_accounting_periods.period_number',
-                'pp_accounting_periods.date_from',
-                'pp_accounting_periods.date_to',
+                'pp_accounting_periods.period_number as pp_period_number',
+                'pp_accounting_periods.date_from as pp_date_from',
+                'pp_accounting_periods.date_to as pp_date_to',
 
                 // Income Tax Payments
                 'income_tax_payments.total_paid as income_tax_amount',
-                'itp_accounting_periods.period_number',
-                'itp_accounting_periods.date_from',
-                'itp_accounting_periods.date_to',
-                // 'itp_pp.date_from',
-                // 'itp_pp.date_to',
+                'itp_accounting_periods.period_number as itp_period_number',
+                'itp_accounting_periods.date_from as itp_date_from',
+                'itp_accounting_periods.date_to as itp_date_to',
+                
                 // TODO: implement commission
             )
             ->leftJoin('vendors', 'payment_references.vendor_id', '=', 'vendors.id')

--- a/resources/views/vendors/payments/payment.blade.php
+++ b/resources/views/vendors/payments/payment.blade.php
@@ -361,8 +361,10 @@
                                     <td>{{ $payment->id }}</td>
                                     <td>{{ $payment->date }}</td>
                                     <td>
-                                        @if($payment->type == 'payroll_payment' || $payment->type == 'income_tax_payment')
-                                            {{ "For Period # " . $payment->period_number . " (" . $payment->date_from . " - " . $payment->date_to . ")" }}
+                                        @if($payment->type == 'payroll_payment')
+                                            {{ "For Period # " . $payment->pp_period_number . " (" . $payment->pp_date_from . " - " . $payment->pp_date_to . ")" }}
+                                        @elseif($payment->type == 'income_tax_payment')
+                                            {{ "For Period # " . $payment->itp_period_number . " (" . $payment->itp_date_from . " - " . $payment->itp_date_to . ")" }}
                                         @else
                                             {{ $payment->name }}
                                         @endif


### PR DESCRIPTION
Fix index() description for payroll payments not showing due to conflict with income tax column names